### PR TITLE
Remove the check for gas limit elasticity

### DIFF
--- a/crates/ethereum/consensus/Cargo.toml
+++ b/crates/ethereum/consensus/Cargo.toml
@@ -18,3 +18,6 @@ reth-primitives.workspace = true
 reth-consensus.workspace = true
 
 tracing.workspace = true
+
+[features]
+telos = []

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -60,6 +60,7 @@ impl EthBeaconConsensus {
                 parent.gas_limit
             };
 
+        #[cfg(not(feature = "telos"))]
         // Check for an increase in gas limit beyond the allowed threshold.
         if header.gas_limit > parent_gas_limit {
             if header.gas_limit - parent_gas_limit >= parent_gas_limit / 1024 {

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -43,4 +43,5 @@ default = ["std"]
 std = []
 telos = [
     "dep:reth-telos-rpc-engine-api",
+    "reth-ethereum-consensus/telos",
 ]


### PR DESCRIPTION
Since we have large gas_limit transactions on mainnet, we need to be able to adjust gas limit for blocks up quickly for these transactions, and similarly reduce it back to the default afterwards.

```
    /// Checks the gas limit for consistency between parent and self headers.
    ///
    /// The maximum allowable difference between self and parent gas limits is determined by the
    /// parent's gas limit divided by the elasticity multiplier (1024).
 ```