### PR TITLE
[WIP] Force telos state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9436,6 +9436,7 @@ dependencies = [
  "reth-basic-payload-builder",
  "reth-beacon-consensus",
  "reth-chainspec",
+ "reth-db",
  "reth-e2e-test-utils",
  "reth-ethereum-engine-primitives",
  "reth-ethereum-payload-builder",
@@ -12113,10 +12114,12 @@ dependencies = [
 name = "telos-reth"
 version = "1.0.8"
 dependencies = [
+ "alloy-primitives",
  "clap",
  "reth",
  "reth-chainspec",
  "reth-cli-util",
+ "reth-db",
  "reth-node-builder",
  "reth-node-telos",
  "reth-provider",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "antelope-client"
+version = "0.3.0"
+source = "git+https://github.com/telosnetwork/antelope-rs#ccd4422e8ce77a57a1f2945785d809348443d327"
+dependencies = [
+ "antelope-client-macros",
+ "async-trait",
+ "base64 0.21.7",
+ "bs58",
+ "chrono",
+ "digest 0.10.7",
+ "ecdsa",
+ "flate2",
+ "hex",
+ "hmac 0.12.1",
+ "k256",
+ "log",
+ "once_cell",
+ "p256",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "reqwest 0.11.27",
+ "ripemd",
+ "serde",
+ "serde-big-array",
+ "serde_json",
+ "sha2 0.10.8",
+ "signature",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "antelope-client-macros"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9392,7 +9425,7 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types",
  "alloy-transport-http 0.4.2",
- "antelope-client",
+ "antelope-client 0.3.0",
  "clap",
  "derive_more 1.0.0",
  "env_logger 0.11.5",
@@ -10575,7 +10608,7 @@ dependencies = [
  "alloy-network 0.4.2",
  "alloy-primitives",
  "alloy-rpc-types 0.4.2",
- "antelope-client",
+ "antelope-client 0.3.0",
  "async-trait",
  "derive_more 1.0.0",
  "jsonrpsee-types",
@@ -12048,7 +12081,7 @@ dependencies = [
  "alloy",
  "alloy-consensus 0.3.6",
  "alloy-rlp",
- "antelope-client",
+ "antelope-client 0.2.1",
  "arrowbatch",
  "base64 0.22.1",
  "bytes",
@@ -12100,7 +12133,7 @@ dependencies = [
  "alloy-consensus 0.3.6",
  "alloy-eips 0.3.6",
  "alloy-rlp",
- "antelope-client",
+ "antelope-client 0.2.1",
  "bytes",
  "clap",
  "dashmap 5.5.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8755,6 +8755,7 @@ dependencies = [
  "revm-primitives",
  "secp256k1",
  "serde_json",
+ "sha2 0.10.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "antelope-client"
 version = "0.3.0"
-source = "git+https://github.com/telosnetwork/antelope-rs#ccd4422e8ce77a57a1f2945785d809348443d327"
+source = "git+https://github.com/telosnetwork/antelope-rs?branch=master#fea2203b2edb5cfcedd5365031e5286b47dc5c66"
 dependencies = [
  "antelope-client-macros",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10620,6 +10620,7 @@ dependencies = [
  "revm",
  "revm-primitives",
  "serde",
+ "sha2 0.10.8",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9417,6 +9417,7 @@ dependencies = [
  "reth-rpc",
  "reth-stages",
  "reth-telos-rpc",
+ "reth-telos-rpc-engine-api 1.0.8",
  "reth-tracing",
  "reth-transaction-pool",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -601,7 +601,7 @@ reth-node-telos = { path = "crates/telos/node" }
 reth-telos-rpc = { path = "crates/telos/rpc" }
 reth-telos-primitives-traits = { path = "crates/telos/primitives-traits" }
 reth-telos-rpc-engine-api = { path = "crates/telos/rpc-engine-api" }
-antelope-client = { git = "https://github.com/telosnetwork/antelope-rs", ref = "2c4df386b36a79a7613e899febb3e32334e714dd" }
+antelope-client = { git = "https://github.com/telosnetwork/antelope-rs", branch = "master" }
 
 [patch.crates-io]
 #alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "8c499409"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -601,7 +601,7 @@ reth-node-telos = { path = "crates/telos/node" }
 reth-telos-rpc = { path = "crates/telos/rpc" }
 reth-telos-primitives-traits = { path = "crates/telos/primitives-traits" }
 reth-telos-rpc-engine-api = { path = "crates/telos/rpc-engine-api" }
-antelope-client = { git = "https://github.com/telosnetwork/antelope-rs", ref = "1989a54ba5adb1f145c0458dba27f15c2d317446" }
+antelope-client = { git = "https://github.com/telosnetwork/antelope-rs", ref = "2c4df386b36a79a7613e899febb3e32334e714dd" }
 
 [patch.crates-io]
 #alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "8c499409"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -601,7 +601,7 @@ reth-node-telos = { path = "crates/telos/node" }
 reth-telos-rpc = { path = "crates/telos/rpc" }
 reth-telos-primitives-traits = { path = "crates/telos/primitives-traits" }
 reth-telos-rpc-engine-api = { path = "crates/telos/rpc-engine-api" }
-antelope-client = { git = "https://github.com/telosnetwork/antelope-rs", branch = "development" }
+antelope-client = { git = "https://github.com/telosnetwork/antelope-rs", ref = "1989a54ba5adb1f145c0458dba27f15c2d317446" }
 
 [patch.crates-io]
 #alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "8c499409"}

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -20,6 +20,7 @@ reth-revm.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-prune-types.workspace = true
 reth-execution-types.workspace = true
+sha2.workspace = true
 
 # Ethereum
 revm-primitives.workspace = true

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -263,24 +263,24 @@ where
             new_addresses_using_create_iter.next();
         }
 
-        #[cfg(feature = "telos")]
-        {
-            // Perform state diff comparision
-            let revm_state_diffs = evm.db_mut().transition_state.clone().unwrap_or_default().transitions;
-            let block_num = block.block.header.number;
-            println!(
-                "Compare: block {block_num} {}",
-                compare_state_diffs(
-                    &mut evm,
-                    revm_state_diffs,
-                    unwrapped_telos_extra_fields.statediffs_account.clone().unwrap_or_default(),
-                    unwrapped_telos_extra_fields.statediffs_accountstate.clone().unwrap_or_default(),
-                    unwrapped_telos_extra_fields.new_addresses_using_create.clone().unwrap_or_default(),
-                    unwrapped_telos_extra_fields.new_addresses_using_openwallet.clone().unwrap_or_default(),
-                    false
-                )
-            );
-        }
+        // #[cfg(feature = "telos")]
+        // {
+        //     // Perform state diff comparision
+        //     let revm_state_diffs = evm.db_mut().transition_state.clone().unwrap_or_default().transitions;
+        //     let block_num = block.block.header.number;
+        //     println!(
+        //         "Compare: block {block_num} {}",
+        //         compare_state_diffs(
+        //             &mut evm,
+        //             revm_state_diffs,
+        //             unwrapped_telos_extra_fields.statediffs_account.clone().unwrap_or_default(),
+        //             unwrapped_telos_extra_fields.statediffs_accountstate.clone().unwrap_or_default(),
+        //             unwrapped_telos_extra_fields.new_addresses_using_create.clone().unwrap_or_default(),
+        //             unwrapped_telos_extra_fields.new_addresses_using_openwallet.clone().unwrap_or_default(),
+        //             false
+        //         )
+        //     );
+        // }
 
         #[cfg(feature = "telos")]
         let receipts = if unwrapped_telos_extra_fields.receipts.is_some() {

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -68,12 +68,12 @@ impl<EvmConfig> EthExecutorProvider<EvmConfig> {
 }
 
 impl<EvmConfig> EthExecutorProvider<EvmConfig>
-    where
-        EvmConfig: ConfigureEvm<Header = Header>,
+where
+    EvmConfig: ConfigureEvm<Header = Header>,
 {
     fn eth_executor<DB>(&self, db: DB) -> EthBlockExecutor<EvmConfig, DB>
-        where
-            DB: Database<Error: Into<ProviderError>>,
+    where
+        DB: Database<Error: Into<ProviderError>>,
     {
         EthBlockExecutor::new(
             self.chain_spec.clone(),
@@ -84,25 +84,25 @@ impl<EvmConfig> EthExecutorProvider<EvmConfig>
 }
 
 impl<EvmConfig> BlockExecutorProvider for EthExecutorProvider<EvmConfig>
-    where
-        EvmConfig: ConfigureEvm<Header = Header>,
+where
+    EvmConfig: ConfigureEvm<Header = Header>,
 {
     type Executor<DB: Database<Error: Into<ProviderError> + Display>> =
-    EthBlockExecutor<EvmConfig, DB>;
+        EthBlockExecutor<EvmConfig, DB>;
 
     type BatchExecutor<DB: Database<Error: Into<ProviderError> + Display>> =
-    EthBatchExecutor<EvmConfig, DB>;
+        EthBatchExecutor<EvmConfig, DB>;
 
     fn executor<DB>(&self, db: DB) -> Self::Executor<DB>
-        where
-            DB: Database<Error: Into<ProviderError> + Display>,
+    where
+        DB: Database<Error: Into<ProviderError> + Display>,
     {
         self.eth_executor(db)
     }
 
     fn batch_executor<DB>(&self, db: DB) -> Self::BatchExecutor<DB>
-        where
-            DB: Database<Error: Into<ProviderError> + Display>,
+    where
+        DB: Database<Error: Into<ProviderError> + Display>,
     {
         let executor = self.eth_executor(db);
         EthBatchExecutor { executor, batch_record: BlockBatchRecord::default() }
@@ -127,8 +127,8 @@ struct EthEvmExecutor<EvmConfig> {
 }
 
 impl<EvmConfig> EthEvmExecutor<EvmConfig>
-    where
-        EvmConfig: ConfigureEvm<Header = Header>,
+where
+    EvmConfig: ConfigureEvm<Header = Header>,
 {
     /// Executes the transactions in the block and returns the receipts of the transactions in the
     /// block, the total gas used and the list of EIP-7685 [requests](Request).
@@ -147,20 +147,20 @@ impl<EvmConfig> EthEvmExecutor<EvmConfig>
         #[cfg(feature = "telos")]
         telos_extra_fields: Option<TelosEngineAPIExtraFields>,
     ) -> Result<EthExecuteOutput, BlockExecutionError>
-        where
-            DB: Database,
-            DB::Error: Into<ProviderError> + Display,
+    where
+        DB: Database,
+        DB::Error: Into<ProviderError> + Display,
     {
         let mut system_caller = SystemCaller::new(&self.evm_config, &self.chain_spec);
 
         system_caller.apply_pre_execution_changes(block, &mut evm)?;
 
         #[cfg(feature = "telos")]
-            let mut tx_index = 0;
+        let mut tx_index = 0;
         #[cfg(feature = "telos")]
-            let unwrapped_telos_extra_fields = telos_extra_fields.unwrap_or_default();
+        let unwrapped_telos_extra_fields = telos_extra_fields.unwrap_or_default();
         #[cfg(feature = "telos")]
-            let mut new_addresses_using_create_iter = unwrapped_telos_extra_fields.new_addresses_using_create.as_ref().unwrap().into_iter().peekable();
+        let mut new_addresses_using_create_iter = unwrapped_telos_extra_fields.new_addresses_using_create.as_ref().unwrap().into_iter().peekable();
         // #[cfg(feature = "telos")]
         // let parent_telos_ext;
         // #[cfg(feature = "telos")]
@@ -195,7 +195,7 @@ impl<EvmConfig> EthEvmExecutor<EvmConfig>
         // execute transactions
         let mut cumulative_gas_used = 0;
         #[cfg(not(feature = "telos"))]
-            let mut receipts = Vec::with_capacity(block.body.transactions.len());
+        let mut receipts = Vec::with_capacity(block.body.transactions.len());
         for (sender, transaction) in block.transactions_with_sender() {
             #[cfg(feature = "telos")]
             while new_addresses_using_create_iter.peek().is_some() && new_addresses_using_create_iter.peek().unwrap().0 == tx_index {
@@ -217,7 +217,7 @@ impl<EvmConfig> EthEvmExecutor<EvmConfig>
                     transaction_gas_limit: transaction.gas_limit(),
                     block_available_gas,
                 }
-                    .into())
+                .into())
             }
 
             self.evm_config.fill_tx_env(evm.tx_mut(), transaction, *sender, #[cfg(feature = "telos")] block.header.telos_block_extension.tx_env_at(tx_index));
@@ -374,9 +374,9 @@ impl<EvmConfig, DB> EthBlockExecutor<EvmConfig, DB> {
 }
 
 impl<EvmConfig, DB> EthBlockExecutor<EvmConfig, DB>
-    where
-        EvmConfig: ConfigureEvm<Header = Header>,
-        DB: Database<Error: Into<ProviderError> + Display>,
+where
+    EvmConfig: ConfigureEvm<Header = Header>,
+    DB: Database<Error: Into<ProviderError> + Display>,
 {
     /// Configures a new evm configuration and block environment for the given block.
     ///
@@ -470,9 +470,9 @@ impl<EvmConfig, DB> EthBlockExecutor<EvmConfig, DB>
 }
 
 impl<EvmConfig, DB> Executor<DB> for EthBlockExecutor<EvmConfig, DB>
-    where
-        EvmConfig: ConfigureEvm<Header = Header>,
-        DB: Database<Error: Into<ProviderError> + Display>,
+where
+    EvmConfig: ConfigureEvm<Header = Header>,
+    DB: Database<Error: Into<ProviderError> + Display>,
 {
     type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
     type Output = BlockExecutionOutput<Receipt>;
@@ -501,8 +501,8 @@ impl<EvmConfig, DB> Executor<DB> for EthBlockExecutor<EvmConfig, DB>
         #[cfg(feature = "telos")]
         telos_extra_fields: Option<TelosEngineAPIExtraFields>
     ) -> Result<Self::Output, Self::Error>
-        where
-            F: FnMut(&State<DB>),
+    where
+        F: FnMut(&State<DB>),
     {
         let BlockExecutionInput { block, total_difficulty } = input;
         let EthExecuteOutput { receipts, requests, gas_used } =
@@ -536,9 +536,9 @@ impl<EvmConfig, DB> EthBatchExecutor<EvmConfig, DB> {
 }
 
 impl<EvmConfig, DB> BatchExecutor<DB> for EthBatchExecutor<EvmConfig, DB>
-    where
-        EvmConfig: ConfigureEvm<Header = Header>,
-        DB: Database<Error: Into<ProviderError> + Display>,
+where
+    EvmConfig: ConfigureEvm<Header = Header>,
+    DB: Database<Error: Into<ProviderError> + Display>,
 {
     type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
     type Output = ExecutionOutcome;
@@ -1392,8 +1392,8 @@ mod tests {
                         header,
                         body: BlockBody { transactions: vec![tx], ..Default::default() },
                     }
-                        .with_recovered_senders()
-                        .unwrap(),
+                    .with_recovered_senders()
+                    .unwrap(),
                     U256::ZERO,
                 )
                     .into(),

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -283,7 +283,7 @@ where
         }
 
         #[cfg(feature = "telos")]
-            let receipts = if unwrapped_telos_extra_fields.receipts.is_some() {
+        let receipts = if unwrapped_telos_extra_fields.receipts.is_some() {
             unwrapped_telos_extra_fields.receipts.clone().unwrap()
         } else {
             vec![]

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -271,7 +271,8 @@ where
                 unwrapped_telos_extra_fields.statediffs_account.unwrap_or_default(),
                 unwrapped_telos_extra_fields.statediffs_accountstate.unwrap_or_default(),
                 unwrapped_telos_extra_fields.new_addresses_using_create.unwrap_or_default(),
-                unwrapped_telos_extra_fields.new_addresses_using_openwallet.unwrap_or_default()
+                unwrapped_telos_extra_fields.new_addresses_using_openwallet.unwrap_or_default(),
+                true
             )
         );
         }

--- a/crates/telos/bin/Cargo.toml
+++ b/crates/telos/bin/Cargo.toml
@@ -16,6 +16,8 @@ reth-chainspec.workspace = true
 reth-provider.workspace = true
 reth-node-telos.workspace = true
 reth-telos-rpc.workspace = true
+reth-db.workspace = true
+alloy-primitives.workspace = true
 
 
 clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/telos/bin/src/main.rs
+++ b/crates/telos/bin/src/main.rs
@@ -4,6 +4,7 @@
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
 use clap::Parser;
+use tracing::{info, warn};
 use reth::args::utils::EthereumChainSpecParser;
 use reth_node_builder::{engine_tree_config::TreeConfig, EngineNodeLauncher};
 use reth::cli::Cli;
@@ -11,6 +12,10 @@ use reth_node_telos::{TelosArgs, TelosNode};
 use reth_node_telos::node::TelosAddOns;
 use reth_provider::providers::BlockchainProvider2;
 use reth_telos_rpc::TelosClient;
+use reth::primitives::BlockId;
+use reth::rpc::types::BlockNumberOrTag;
+use reth_provider::{DatabaseProviderFactory, StateProviderFactory};
+use reth_db::{PlainAccountState, PlainStorageState};
 
 
 #[cfg(feature = "telos")]
@@ -45,6 +50,10 @@ fn main() {
                 handle.node_exit_future.await
             },
             false => {
+                let two_way_storage_compare = telos_args.two_way_storage_compare.clone();
+                let telos_rpc = telos_args.telos_endpoint.clone();
+                let block_delta = telos_args.block_delta.clone();
+
                 let handle = builder
                     .node(TelosNode::new(telos_args.clone()))
                     .extend_rpc_modules(move |ctx| {
@@ -58,6 +67,32 @@ fn main() {
                     })
                     .launch()
                     .await?;
+
+                match two_way_storage_compare {
+                    true => {
+                        if telos_rpc.is_none() {
+                            warn!("Telos RPC Endpoint is not specified, skipping two-way storage compare");
+                        } else if block_delta.is_none() {
+                            warn!("Block delta is not specified, skipping two-way storage compare");
+                        } else {
+                            info!("Fetching account and accountstate from Telos native RPC (Can take a long time)...");
+
+                            let (account_table, accountstate_table, block_number) = reth_node_telos::two_way_storage_compare::get_telos_tables(telos_rpc.unwrap().as_str(), block_delta.unwrap()).await;
+
+                            info!("Two-way comparing state (Reth vs. Telos) at height: {:?}", block_number);
+
+                            let state_at_specific_height = handle.node.provider.state_by_block_id(BlockId::Number(BlockNumberOrTag::Number(block_number.as_u64().unwrap()))).unwrap();
+                            let plain_account_state = handle.node.provider.database_provider_ro().unwrap().table::<PlainAccountState>().unwrap();
+                            let plain_storage_state = handle.node.provider.database_provider_ro().unwrap().table::<PlainStorageState>().unwrap();
+
+                            let match_counter = reth_node_telos::two_way_storage_compare::two_side_state_compare(account_table, accountstate_table, state_at_specific_height, plain_account_state, plain_storage_state).await;
+                            match_counter.print();
+
+                            info!("Comparing done");
+                        }
+                    }
+                    _ => {}
+                }
 
                 handle.node_exit_future.await
             }

--- a/crates/telos/node/Cargo.toml
+++ b/crates/telos/node/Cargo.toml
@@ -35,6 +35,8 @@ reth-telos-rpc.workspace = true
 reth-tracing.workspace = true
 reth-transaction-pool.workspace = true
 reth-telos-rpc-engine-api.workspace = true
+alloy-primitives.workspace = true
+reth-db.workspace = true
 
 clap.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/telos/node/Cargo.toml
+++ b/crates/telos/node/Cargo.toml
@@ -34,6 +34,7 @@ reth-stages.workspace = true
 reth-telos-rpc.workspace = true
 reth-tracing.workspace = true
 reth-transaction-pool.workspace = true
+reth-telos-rpc-engine-api.workspace = true
 
 clap.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/telos/node/src/args.rs
+++ b/crates/telos/node/src/args.rs
@@ -45,6 +45,14 @@ pub struct TelosArgs {
     /// a batch of downloaded blocks.
     #[arg(long = "engine.max-execute-block-batch-size", requires = "experimental", default_value_t = DEFAULT_MAX_EXECUTE_BLOCK_BATCH_SIZE)]
     pub max_execute_block_batch_size: usize,
+
+    /// Enable Two-way storage compare between reth and telos
+    #[arg(long = "telos.two_way_storage_compare", default_value = "false")]
+    pub two_way_storage_compare: bool,
+
+    /// Block delta between native and EVM
+    #[arg(long = "telos.block_delta")]
+    pub block_delta: Option<u32>,
 }
 
 impl From<TelosArgs> for TelosClientArgs {

--- a/crates/telos/node/src/lib.rs
+++ b/crates/telos/node/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod args;
 pub mod node;
+pub mod two_way_storage_compare;
 
 pub use crate::args::TelosArgs;
 pub use crate::node::TelosNode;

--- a/crates/telos/node/src/two_way_storage_compare.rs
+++ b/crates/telos/node/src/two_way_storage_compare.rs
@@ -1,0 +1,360 @@
+//! Two-way storage compare between Reth and Telos
+
+use antelope::serializer::{Decoder, Encoder, Packer};
+use antelope::chain::name::Name;
+use std::collections::HashMap;
+use alloy_primitives::{Address, B256, U256};
+use antelope::api::client::{APIClient, DefaultProvider};
+use antelope::api::v1::structs::{GetTableRowsParams, TableIndexType};
+use antelope::{name, StructPacker};
+use antelope::chain::checksum::{Checksum160, Checksum256};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info};
+use reth::primitives::{Account, BlockId};
+use reth_db::common::KeyValue;
+use reth::providers::StateProviderBox;
+use reth_db::{PlainAccountState, PlainStorageState};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, StructPacker)]
+struct AccountRow {
+    index: u64,
+    address: Checksum160,
+    account: Name,
+    nonce: u64,
+    code: Vec<u8>,
+    balance: Checksum256,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, StructPacker)]
+struct AccountStateRow {
+    index: u64,
+    key: Checksum256,
+    value: Checksum256,
+}
+
+/// This struct holds matching statistics
+#[derive(Debug, Clone, Default)]
+pub struct MatchCounter {
+    total_telos_accounts: u64,
+    total_telos_storages: u64,
+    mismatched_telos_accounts: u64,
+    mismatched_telos_storages: u64,
+    total_reth_accounts: u64,
+    total_reth_storages: u64,
+    mismatched_reth_accounts: u64,
+    mismatched_reth_storages: u64,
+}
+impl MatchCounter {
+    /// Creates a new match counter for two-way storage compare
+    pub fn new() -> Self {
+        Self {
+            total_telos_accounts: 0,
+            total_telos_storages: 0,
+            mismatched_telos_accounts: 0,
+            mismatched_telos_storages: 0,
+            total_reth_accounts: 0,
+            total_reth_storages: 0,
+            mismatched_reth_accounts: 0,
+            mismatched_reth_storages: 0,
+        }
+    }
+
+    /// Prints the match counter
+    pub fn print(&self) {
+        info!("Comparing results:");
+        info!("Total telos accounts: {}", self.total_telos_accounts);
+        info!("Total telos storages: {}", self.total_telos_storages);
+        info!("Mismatched telos accounts: {}", self.mismatched_telos_accounts);
+        info!("Mismatched telos storages: {}", self.mismatched_telos_storages);
+        info!("Total reth accounts: {}", self.total_reth_accounts);
+        info!("Total reth storages: {}", self.total_reth_storages);
+        info!("Mismatched reth accounts: {}", self.mismatched_reth_accounts);
+        info!("Mismatched reth storages: {}", self.mismatched_reth_storages);
+        info!("Matching result: {}",self.matches());
+    }
+
+    fn add_telos_total_account(&mut self) {
+        self.total_telos_accounts += 1;
+    }
+
+    fn add_telos_total_storage(&mut self) {
+        self.total_telos_storages += 1;
+    }
+
+    fn add_telos_mismatched_account(&mut self) {
+        self.mismatched_telos_accounts += 1;
+    }
+
+    fn add_telos_mismatched_storage(&mut self) {
+        self.mismatched_telos_storages += 1;
+    }
+
+    fn add_reth_total_account(&mut self) {
+        self.total_reth_accounts += 1;
+    }
+
+    fn add_reth_total_storage(&mut self) {
+        self.total_reth_storages += 1;
+    }
+
+    fn add_reth_mismatched_account(&mut self) {
+        self.mismatched_reth_accounts += 1;
+    }
+
+    fn add_reth_mismatched_storage(&mut self) {
+        self.mismatched_reth_storages += 1;
+    }
+
+    /// Check whether both sides matches
+    pub fn matches(&self) -> bool {
+        self.mismatched_telos_accounts == 0
+            && self.mismatched_telos_storages == 0
+            && self.mismatched_reth_accounts == 0
+            && self.mismatched_reth_storages == 0
+    }
+}
+
+/// This function compares reth and telos state against each other at specific height
+pub async fn two_side_state_compare(
+    account_table: HashMap<Address, Account>,
+    accountstate_table: HashMap<(Address, B256), U256>,
+    state_at_specific_height: StateProviderBox,
+    plain_account_state: Vec<KeyValue<PlainAccountState>>,
+    plain_storage_state: Vec<KeyValue<PlainStorageState>>,
+) -> MatchCounter {
+
+    let mut match_counter = MatchCounter::new();
+
+    for (address, telos_account) in &account_table {
+        let account_at_specific_height = state_at_specific_height.basic_account(*address);
+        match account_at_specific_height {
+            Ok(reth_account) => {
+                match reth_account {
+                    Some(reth_account) => {
+                        if reth_account.balance != telos_account.balance || reth_account.nonce != telos_account.nonce {
+                            match_counter.add_telos_mismatched_account();
+                            error!("Difference in account: {:?}", address);
+                            error!("Telos side: {:?}", telos_account);
+                            error!("Reth side: {:?}", reth_account);
+                        }
+                    },
+                    None => {
+                        if telos_account.balance != U256::ZERO || telos_account.nonce != 0 {
+                            match_counter.add_telos_mismatched_account();
+                            error!("Difference in account: {:?}", address);
+                            error!("Telos side: {:?}", telos_account);
+                            error!("Reth side: None");
+                        }
+                    },
+                }
+            },
+            Err(_) => {
+                match_counter.add_telos_mismatched_account();
+                error!("Difference in account: {:?}", address);
+                error!("Telos side: {:?}", telos_account);
+                error!("Reth side: None");
+            },
+        }
+        match_counter.add_telos_total_account();
+    }
+
+    for ((address, key), telos_value) in &accountstate_table {
+        let storage_at_specific_height = state_at_specific_height.storage(*address, *key);
+        match storage_at_specific_height {
+            Ok(storage) => {
+                match storage {
+                    Some(reth_value) => {
+                        if reth_value != *telos_value {
+                            match_counter.add_telos_mismatched_storage();
+                            error!("Difference in accountstate: {:?}, key: {:?}", address, key);
+                            error!("Telos side: {:?}", telos_value);
+                            error!("Reth side: {:?}", reth_value);
+                        }
+                    },
+                    None => {
+                        match_counter.add_telos_mismatched_storage();
+                        error!("Difference in accountstate: {:?}, key: {:?}", address, key);
+                        error!("Telos side: {:?}", telos_value);
+                        error!("Reth side: None");
+                    },
+                }
+            },
+            Err(_) => {
+                match_counter.add_telos_mismatched_storage();
+                error!("Difference in accountstate: {:?}, key: {:?}", address, key);
+                error!("Telos side: {:?}", telos_value);
+                error!("Reth side: None");
+            },
+        }
+        match_counter.add_telos_total_storage();
+    }
+
+
+    for (address, _) in plain_account_state.iter() {
+        let account_at_specific_height = state_at_specific_height.basic_account(*address);
+        let telos_account = account_table.get(address);
+        match account_at_specific_height {
+            Ok(account) => {
+                match account {
+                    Some(reth_account) => {
+                        if telos_account.is_none() {
+                            match_counter.add_reth_mismatched_account();
+                            error!("Difference in account: {:?}", address);
+                            error!("Telos side: None");
+                            error!("Reth side: {:?}", reth_account);
+                        } else {
+                            let telos_account_unwrapped = telos_account.unwrap();
+                            if reth_account.balance != telos_account_unwrapped.balance || reth_account.nonce != telos_account_unwrapped.nonce {
+                                match_counter.add_reth_mismatched_account();
+                                error!("Difference in account: {:?}", address);
+                                error!("Telos side: {:?}", telos_account);
+                                error!("Reth side: {:?}", reth_account);
+                            }
+                        }
+
+                    },
+                    None => {
+                        if telos_account.is_some() {
+                            match_counter.add_reth_mismatched_account();
+                            error!("Difference in account: {:?}", address);
+                            error!("Telos side: {:?}", telos_account.unwrap());
+                            error!("Reth side: None");
+                        }
+                    },
+                }
+            },
+            Err(_) => {
+                if telos_account.is_some() {
+                    match_counter.add_reth_mismatched_account();
+                    error!("Difference in account: {:?}", address);
+                    error!("Telos side: {:?}", telos_account.unwrap());
+                    error!("Reth side: None");
+                }
+            },
+        }
+        match_counter.add_reth_total_account();
+    }
+
+    for (address,storage_entry) in plain_storage_state.iter() {
+        let storage_at_specific_height = state_at_specific_height.storage(*address, storage_entry.key);
+        let telos_accountstate = accountstate_table.get(&(*address, storage_entry.key));
+        match storage_at_specific_height {
+            Ok(storage) => {
+                match storage {
+                    Some(reth_value) => {
+                        if telos_accountstate.is_none() {
+                            if reth_value != U256::ZERO {
+                                match_counter.add_reth_mismatched_storage();
+                                error!("Difference in accountstate: {:?}", address);
+                                error!("Telos side: None");
+                                error!("Reth side: {:?}", reth_value);
+                            }
+                        } else {
+                            let telos_value = *telos_accountstate.unwrap();
+                            if reth_value != telos_value {
+                                match_counter.add_reth_mismatched_storage();
+                                error!("Difference in accountstate: {:?}", address);
+                                error!("Telos side: {:?}", telos_value);
+                                error!("Reth side: {:?}", reth_value);
+                            }
+                        }
+                    },
+                    None => {
+                        if telos_accountstate.is_some() {
+                            match_counter.add_reth_mismatched_storage();
+                            error!("Difference in accountstate: {:?}", address);
+                            error!("Telos side: {:?}", telos_accountstate.unwrap());
+                            error!("Reth side: None");
+                        }
+                    },
+                }
+            },
+            Err(_) => {
+                if telos_accountstate.is_some() {
+                    match_counter.add_reth_mismatched_storage();
+                    error!("Difference in accountstate: {:?}", address);
+                    error!("Telos side: {:?}", telos_accountstate.unwrap());
+                    error!("Reth side: None");
+                }
+            },
+        }
+        match_counter.add_reth_total_storage();
+    }
+
+    match_counter
+}
+
+/// This function retrieves account and accountstate tables from native RPC
+pub async fn get_telos_tables(telos_rpc: &str, block_delta: u32) -> (HashMap<Address, Account>, HashMap<(Address, B256), U256>, BlockId) {
+
+    let api_client = APIClient::<DefaultProvider>::default_provider(telos_rpc.into(), Some(5)).unwrap();
+    let info = api_client.v1_chain.get_info().await.unwrap();
+
+    let evm_block_num = info.head_block_num - block_delta;
+
+    let mut has_more_account = true;
+    let mut lower_bound_account = Some(TableIndexType::UINT64(0));
+
+    let evm_block_id = BlockId::from(evm_block_num as u64);
+
+    let mut account_table = HashMap::default();
+    let mut accountstate_table = HashMap::default();
+
+    while has_more_account {
+        let query_params_account = GetTableRowsParams {
+            code: name!("eosio.evm"),
+            table: name!("account"),
+            scope: None,
+            lower_bound: lower_bound_account,
+            upper_bound: None,
+            limit: Some(5000),
+            reverse: None,
+            index_position: None,
+            show_payer: None,
+        };
+        let account_rows = api_client.v1_chain.get_table_rows::<AccountRow>(query_params_account).await;
+        if let Ok(account_rows) = account_rows {
+            lower_bound_account = account_rows.next_key;
+            has_more_account = lower_bound_account.is_some();
+            for account_row in account_rows.rows {
+                let address = Address::from_slice(account_row.address.data.as_slice());
+                lower_bound_account = Some(TableIndexType::UINT64(account_row.index + 1));
+                account_table.insert(address,Account {
+                    nonce: account_row.nonce,
+                    balance: U256::from_be_bytes(account_row.balance.data),
+                    bytecode_hash: None,
+                });
+                let mut has_more_accountstate = true;
+                let mut lower_bound_accountstate = Some(TableIndexType::UINT64(0));
+                while has_more_accountstate {
+                    let query_params_accountstate = GetTableRowsParams {
+                        code: name!("eosio.evm"),
+                        table: name!("accountstate"),
+                        scope: Some(Name::from_u64(account_row.index)),
+                        lower_bound: lower_bound_accountstate,
+                        upper_bound: None,
+                        limit: Some(5000),
+                        reverse: None,
+                        index_position: None,
+                        show_payer: None,
+                    };
+                    let accountstate_rows = api_client.v1_chain.get_table_rows::<AccountStateRow>(query_params_accountstate).await;
+                    if let Ok(accountstate_rows) = accountstate_rows {
+                        lower_bound_accountstate = accountstate_rows.next_key;
+                        has_more_accountstate = lower_bound_accountstate.is_some();
+                        for accountstate_row in accountstate_rows.rows {
+                            lower_bound_accountstate = Some(TableIndexType::UINT64(accountstate_row.index + 1));
+                            accountstate_table.insert((address,B256::from(accountstate_row.key.data)),U256::from_be_bytes(accountstate_row.value.data));
+                        }
+                    } else {
+                        panic!("Failed to fetch accountstate row");
+                    }
+                }
+            }
+        } else {
+            panic!("Failed to fetch account row");
+        }
+    }
+
+    (account_table, accountstate_table, evm_block_id)
+}

--- a/crates/telos/node/tests/integration.rs
+++ b/crates/telos/node/tests/integration.rs
@@ -160,6 +160,8 @@ async fn testing_chain_sync() {
         persistence_threshold: 0,
         memory_block_buffer_target: 1,
         max_execute_block_batch_size: 100,
+        two_way_storage_compare: false,
+        block_delta: None,
     };
 
     let node_handle = NodeBuilder::new(node_config.clone())

--- a/crates/telos/node/tests/main.rs
+++ b/crates/telos/node/tests/main.rs
@@ -1,4 +1,5 @@
-mod integration;
-pub mod live_test_runner;
+// mod integration;
+// pub mod live_test_runner;
+pub mod storage_compare;
 
 const fn main() {}

--- a/crates/telos/node/tests/state_bypass.rs
+++ b/crates/telos/node/tests/state_bypass.rs
@@ -1,0 +1,390 @@
+use std::{fmt, fs};
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+use alloy_provider::{Provider, ProviderBuilder};
+use reqwest::Url;
+use serde_json::json;
+use telos_consensus_client::execution_api_client::{ExecutionApiClient, RpcRequest};
+use telos_consensus_client::execution_api_client::ExecutionApiMethod::{ForkChoiceUpdatedV1, NewPayloadV1};
+use tracing::info;
+use reth::args::RpcServerArgs;
+use reth::builder::NodeConfig;
+use alloy_primitives::{Address, B256, hex, U256, Bytes, map::HashMap};
+use alloy_primitives::hex::FromHex;
+use alloy_rpc_types::engine::ExecutionPayloadV1;
+use reth::primitives::revm_primitives::{Bytecode as RevmBytecode, LegacyAnalyzedBytecode};
+use reth::revm;
+use reth::revm::db::{CacheDB, EmptyDBTyped, StorageWithOriginalValues, states::StorageSlot};
+use reth::revm::{Database, DatabaseCommit, DatabaseRef, Evm, State, TransitionAccount};
+use reth::revm::primitives::{AccountInfo, EvmStorageSlot};
+use reth::rpc::types::engine::ForkchoiceState;
+use reth::tasks::TaskManager;
+use reth_chainspec::{ChainSpec, ChainSpecBuilder, TEVMTESTNET};
+use reth_e2e_test_utils::node::NodeTestContext;
+use reth_node_builder::NodeBuilder;
+use reth_node_telos::{TelosArgs, TelosNode};
+use reth_primitives::constants::{EMPTY_ROOT_HASH, MIN_PROTOCOL_BASE_FEE};
+use reth_primitives::revm_primitives::AccountStatus;
+use reth_telos_rpc::TelosClient;
+use reth_telos_rpc_engine_api::compare::compare_state_diffs;
+use reth_telos_rpc_engine_api::structs::{TelosAccountTableRow, TelosAccountStateTableRow, TelosEngineAPIExtraFields};
+use revm::primitives::Account;
+
+enum MockDBError {
+    GenericError(String)
+}
+
+fn init_reth() -> eyre::Result<(NodeConfig<ChainSpec>, String)> {
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(TEVMTESTNET.chain)
+            .genesis(TEVMTESTNET.genesis.clone())
+            .frontier_activated()
+            .homestead_activated()
+            .tangerine_whistle_activated()
+            .spurious_dragon_activated()
+            .byzantium_activated()
+            .constantinople_activated()
+            .petersburg_activated()
+            .istanbul_activated()
+            .berlin_activated()
+            .build(),
+    );
+
+    let mut rpc_config = RpcServerArgs::default().with_unused_ports().with_http();
+    rpc_config.auth_jwtsecret = Some(PathBuf::from("tests/assets/jwt.hex"));
+
+    // Node setup
+    let node_config = NodeConfig::test().with_chain(chain_spec).with_rpc(rpc_config.clone());
+
+    let jwt = fs::read_to_string(node_config.rpc.auth_jwtsecret.clone().unwrap())?;
+    Ok((node_config, jwt))
+}
+
+#[tokio::test]
+async fn test_integration_tevm_only() {
+    tracing_subscriber::fmt::init();
+
+    let (node_config, jwt_secret) = init_reth().unwrap();
+
+    let exec = TaskManager::current();
+    let exec = exec.executor();
+
+    reth_tracing::init_test_tracing();
+
+    let telos_args = TelosArgs {
+        telos_endpoint: None,
+        signer_account: Some("rpc.evm".to_string()),
+        signer_permission: Some("active".to_string()),
+        signer_key: Some("5Jr65kdYmn33C3UabzhmWDm2PuqbRfPuDStts3ZFNSBLM7TqaiL".to_string()),
+        gas_cache_seconds: None,
+        experimental: false,
+        persistence_threshold: 0,
+        memory_block_buffer_target: 0,
+        max_execute_block_batch_size: 0,
+    };
+
+    let node_handle = NodeBuilder::new(node_config.clone())
+        .testing_node(exec)
+        .node(TelosNode::new(telos_args.clone()))
+        .extend_rpc_modules(move |ctx| {
+            if telos_args.telos_endpoint.is_some() {
+                ctx.registry.eth_api().set_telos_client(TelosClient::new(telos_args.into()));
+            }
+
+            Ok(())
+        })
+        .launch()
+        .await
+        .unwrap();
+
+    let execution_port = node_handle.node.auth_server_handle().local_addr().port();
+    let rpc_port = node_handle.node.rpc_server_handles.rpc.http_local_addr().unwrap().port();
+    println!("Starting Reth on RPC port {}!", rpc_port);
+    let _ = NodeTestContext::new(node_handle.node.clone()).await.unwrap();
+
+    let custom_balance = U256::from(80085);
+
+    let exec_client = ExecutionApiClient::new(&format!("http://127.0.0.1:{}", execution_port), &jwt_secret).unwrap();
+
+    let execution_payload = ExecutionPayloadV1 {
+        parent_hash: B256::from_hex("b25034033c9ca7a40e879ddcc29cf69071a22df06688b5fe8cc2d68b4e0528f9").unwrap(),
+        fee_recipient: Default::default(),
+        state_root: EMPTY_ROOT_HASH,
+        receipts_root: EMPTY_ROOT_HASH,
+        logs_bloom: Default::default(),
+        prev_randao: Default::default(),
+        block_number: 1,
+        gas_limit: 0x7fffffff,
+        gas_used: 0,
+        timestamp: 1728067687,
+        extra_data: Default::default(),
+        base_fee_per_gas: U256::try_from(MIN_PROTOCOL_BASE_FEE).unwrap(),
+        block_hash: B256::from_hex("0a1d73423169c8b4124121d40c0e13eb078621e73effd2d183f9a1d8017537dd").unwrap(),
+        transactions: vec![],
+    };
+
+    let test_addr = Address::from_hex("00000000000000000000000000000000deadbeef").unwrap();
+
+    let extra_fields = TelosEngineAPIExtraFields {
+        statediffs_account: Some(vec![TelosAccountTableRow {
+            removed: false,
+            address: test_addr,
+            account: "eosio".to_string(),
+            nonce: 0,
+            code: Default::default(),
+            balance: custom_balance,
+        }]),
+        statediffs_accountstate: Some(vec![]),
+        revision_changes: None,
+        gasprice_changes: None,
+        new_addresses_using_create: Some(vec![]),
+        new_addresses_using_openwallet: Some(vec![]),
+        receipts: Some(vec![]),
+    };
+
+    let block_req = RpcRequest {
+        method: NewPayloadV1,
+        params: vec![
+            json![execution_payload],
+            json![extra_fields]
+        ].into()
+    };
+
+    let new_block_result = exec_client.rpc(block_req).await.unwrap();
+
+    info!("new_block: {:#?}", new_block_result);
+
+    let fork_choice_result = exec_client.rpc(RpcRequest {
+        method: ForkChoiceUpdatedV1,
+        params: json![vec![ForkchoiceState {
+            head_block_hash: execution_payload.block_hash,
+            safe_block_hash: execution_payload.block_hash,
+            finalized_block_hash: execution_payload.block_hash
+        }]]
+    }).await.unwrap();
+
+    info!("fork_choice: {:#?}", fork_choice_result);
+
+
+    let provider = ProviderBuilder::new()
+        //.network::<TelosNetwork>()
+        .on_http(Url::from_str(format!("http://localhost:{}", rpc_port).as_str()).unwrap());
+
+    let balance = provider.get_balance(test_addr).await.unwrap();
+    info!("balance: {:#?}", balance);
+
+    assert_eq!(balance, custom_balance);
+}
+
+#[test]
+fn test_db_both_sides_present_but_dif() {
+    let test_addr = Address::from_str("00000000000000000000000000000000deadbeef").unwrap();
+
+    let init_balance = U256::from(0);
+    let custom_balance = U256::from(80085);
+
+    let init_nonce = 0;
+    let custom_nonce = 69;
+
+    let custom_code = Bytes::from(&hex!("ffff"));
+    let custom_bytecode = RevmBytecode::LegacyRaw(custom_code.clone());
+
+    let revm_acc_info = AccountInfo {
+        balance: init_balance,
+        nonce: init_nonce,
+        code_hash: Default::default(),
+        code: None,
+    };
+
+
+    let mut db = CacheDB::new(EmptyDBTyped::new());
+    db.insert_account_info(test_addr, revm_acc_info);
+
+    let mut state = State::builder().with_database(db).build();
+
+    let mut evm = Evm::builder().with_db(&mut state).build();
+
+    let statediffs_account = vec![TelosAccountTableRow {
+        removed: false,
+        address: test_addr,
+        account: "eosio".to_string(),
+        nonce: custom_nonce,
+        code: custom_code.clone(),
+        balance: custom_balance,
+    }];
+
+    compare_state_diffs(
+        &mut evm,
+        HashMap::new(),
+        statediffs_account.clone(),
+        vec![],
+        vec![],
+        vec![]
+    );
+
+    let db_acc = evm.db_mut().basic(test_addr).unwrap().unwrap();
+    assert_eq!(db_acc.nonce, statediffs_account[0].nonce);
+    assert_eq!(db_acc.balance, statediffs_account[0].balance);
+    assert_eq!(db_acc.code, Some(custom_bytecode));
+}
+
+#[test]
+fn test_revm_state_both_sides_present_but_dif() {
+    let test_addr = Address::from_str("00000000000000000000000000000000deadbeef").unwrap();
+
+    let revm_acc_info = AccountInfo {
+        balance: U256::from(80085),
+        nonce: 69,
+        code_hash: Default::default(),
+        code: None,
+    };
+
+    let mut revm_state_diffs = HashMap::new();
+
+    let mut transition_account = TransitionAccount::new_empty_eip161(HashMap::new());
+
+    transition_account.info = Some(revm_acc_info);
+
+    revm_state_diffs.insert(test_addr, transition_account);
+
+    let mut db = CacheDB::new(EmptyDBTyped::new());
+
+    let mut state = State::builder().with_database(db).build();
+
+    let mut evm = Evm::builder().with_db(&mut state).build();
+
+    let statediffs_account = vec![TelosAccountTableRow {
+        removed: false,
+        address: test_addr,
+        account: "eosio".to_string(),
+        nonce: 1,
+        code: Default::default(),
+        balance: U256::from(80085),
+    }];
+
+    compare_state_diffs(
+        &mut evm,
+        revm_state_diffs,
+        statediffs_account.clone(),
+        vec![],
+        vec![],
+        vec![]
+    );
+
+    // let db_acc = evm.db_mut().basic(test_addr).unwrap().unwrap();
+    // assert_eq!(db_acc.nonce, statediffs_account[0].nonce);
+    // assert_eq!(db_acc.balance, statediffs_account[0].balance);
+    // assert_eq!(db_acc.code, Some(custom_bytecode));
+}
+
+#[test]
+fn test_tevm_only() {
+    let test_addr = Address::from_str("00000000000000000000000000000000deadbeef").unwrap();
+
+    let mut db = CacheDB::new(EmptyDBTyped::new());
+
+    let mut state = State::builder().with_database(db).build();
+
+    let mut evm = Evm::builder().with_db(&mut state).build();
+
+    let statediffs_account = vec![TelosAccountTableRow {
+        removed: false,
+        address: test_addr,
+        account: "eosio".to_string(),
+        nonce: 1,
+        code: Default::default(),
+        balance: U256::from(80085),
+    }];
+
+    compare_state_diffs(
+        &mut evm,
+        HashMap::new(),
+        statediffs_account.clone(),
+        vec![],
+        vec![],
+        vec![]
+    );
+
+    let db_acc = evm.db_mut().basic(test_addr).unwrap().unwrap();
+    assert_eq!(db_acc.nonce, statediffs_account[0].nonce);
+    assert_eq!(db_acc.balance, statediffs_account[0].balance);
+}
+
+#[test]
+fn test_accstate_diff_from_storage() {
+    let test_addr = Address::from_str("00000000000000000000000000000000deadbeef").unwrap();
+
+    let revm_acc_info = AccountInfo {
+        balance: U256::from(80085),
+        nonce: 69,
+        code_hash: Default::default(),
+        code: None,
+    };
+
+    let key = U256::from(420);
+    let value = U256::from(0);
+    let custom_value = U256::from(80085);
+
+    let mut db = CacheDB::new(EmptyDBTyped::new());
+
+    let mut storage = HashMap::new();
+    storage.insert(key, value);
+
+    let mut state = State::builder().with_database(db).build();
+
+    state.insert_account_with_storage(test_addr, revm_acc_info, storage);
+
+    let mut evm = Evm::builder().with_db(&mut state).build();
+
+    let statediffs_accountstate = vec![TelosAccountStateTableRow {
+        removed: false,
+        address: test_addr,
+        key,
+        value: custom_value
+    }];
+
+    compare_state_diffs(
+        &mut evm,
+        HashMap::new(),
+        vec![],
+        statediffs_accountstate.clone(),
+        vec![],
+        vec![]
+    );
+
+    let db_value = evm.db_mut().storage(test_addr, key).unwrap();
+    assert_eq!(db_value, custom_value);
+}
+#[test]
+fn test_accstate_telos_only() {
+    let test_addr = Address::from_str("00000000000000000000000000000000deadbeef").unwrap();
+
+    let key = U256::from(420);
+    let custom_value = U256::from(80085);
+
+    let mut db = CacheDB::new(EmptyDBTyped::new());
+
+    let mut state = State::builder().with_database(db).build();
+
+    // state.insert_not_existing(test_addr);
+
+    let mut evm = Evm::builder().with_db(&mut state).build();
+
+    let statediffs_accountstate = vec![TelosAccountStateTableRow {
+        removed: false,
+        address: test_addr,
+        key,
+        value: custom_value
+    }];
+
+    compare_state_diffs(
+        &mut evm,
+        HashMap::new(),
+        vec![],
+        statediffs_accountstate.clone(),
+        vec![],
+        vec![]
+    );
+}

--- a/crates/telos/node/tests/state_bypass.rs
+++ b/crates/telos/node/tests/state_bypass.rs
@@ -244,7 +244,8 @@ fn test_db_both_sides_present_but_dif() {
         statediffs_account.clone(),
         vec![],
         vec![],
-        vec![]
+        vec![],
+        true
     );
 
     let db_acc = evm.db_mut().basic(test_addr).unwrap().unwrap();
@@ -293,7 +294,8 @@ fn test_revm_state_both_sides_present_but_dif() {
         statediffs_account.clone(),
         vec![],
         vec![],
-        vec![]
+        vec![],
+       false
     );
 
     // let db_acc = evm.db_mut().basic(test_addr).unwrap().unwrap();
@@ -327,7 +329,8 @@ fn test_tevm_only() {
         statediffs_account.clone(),
         vec![],
         vec![],
-        vec![]
+        vec![],
+        true
     );
 
     let db_acc = evm.db_mut().basic(test_addr).unwrap().unwrap();
@@ -374,7 +377,8 @@ fn test_accstate_diff_from_storage() {
         vec![],
         statediffs_accountstate.clone(),
         vec![],
-        vec![]
+        vec![],
+        true
     );
 
     let db_value = evm.db_mut().storage(test_addr, key).unwrap();
@@ -408,6 +412,7 @@ fn test_accstate_telos_only() {
         vec![],
         statediffs_accountstate.clone(),
         vec![],
-        vec![]
+        vec![],
+        true
     );
 }

--- a/crates/telos/node/tests/state_bypass.rs
+++ b/crates/telos/node/tests/state_bypass.rs
@@ -298,8 +298,8 @@ fn test_revm_state_both_sides_present_but_dif() {
     let test_addr = Address::from_str("00000000000000000000000000000000deadbeef").unwrap();
 
     let revm_acc_info = AccountInfo {
-        balance: U256::from(80085),
-        nonce: 69,
+        balance: U256::from(1),
+        nonce: 0,
         code_hash: Default::default(),
         code: None,
     };
@@ -334,13 +334,12 @@ fn test_revm_state_both_sides_present_but_dif() {
         vec![],
         vec![],
         vec![],
-       false
+        false
     );
 
-    // let db_acc = evm.db_mut().basic(test_addr).unwrap().unwrap();
-    // assert_eq!(db_acc.nonce, statediffs_account[0].nonce);
-    // assert_eq!(db_acc.balance, statediffs_account[0].balance);
-    // assert_eq!(db_acc.code, Some(custom_bytecode));
+    let db_acc = evm.db_mut().basic(test_addr).unwrap().unwrap();
+    assert_eq!(db_acc.nonce, statediffs_account[0].nonce);
+    assert_eq!(db_acc.balance, statediffs_account[0].balance);
 }
 
 #[test]
@@ -369,7 +368,7 @@ fn test_tevm_only() {
         vec![],
         vec![],
         vec![],
-        true
+        false
     );
 
     let db_acc = evm.db_mut().basic(test_addr).unwrap().unwrap();
@@ -382,8 +381,8 @@ fn test_accstate_diff_from_storage() {
     let test_addr = Address::from_str("00000000000000000000000000000000deadbeef").unwrap();
 
     let revm_acc_info = AccountInfo {
-        balance: U256::from(80085),
-        nonce: 69,
+        balance: U256::from(1),
+        nonce: 0,
         code_hash: Default::default(),
         code: None,
     };
@@ -417,41 +416,41 @@ fn test_accstate_diff_from_storage() {
         statediffs_accountstate.clone(),
         vec![],
         vec![],
-        true
+        false
     );
 
     let db_value = evm.db_mut().storage(test_addr, key).unwrap();
     assert_eq!(db_value, custom_value);
 }
-#[test]
-fn test_accstate_telos_only() {
-    let test_addr = Address::from_str("00000000000000000000000000000000deadbeef").unwrap();
-
-    let key = U256::from(420);
-    let custom_value = U256::from(80085);
-
-    let mut db = CacheDB::new(EmptyDBTyped::<MockDBError>::new());
-
-    let mut state = State::builder().with_database(db).build();
-
-    // state.insert_not_existing(test_addr);
-
-    let mut evm = Evm::builder().with_db(&mut state).build();
-
-    let statediffs_accountstate = vec![TelosAccountStateTableRow {
-        removed: false,
-        address: test_addr,
-        key,
-        value: custom_value
-    }];
-
-    compare_state_diffs(
-        &mut evm,
-        HashMap::default(),
-        vec![],
-        statediffs_accountstate.clone(),
-        vec![],
-        vec![],
-        true
-    );
-}
+// #[test]
+// fn test_accstate_telos_only() {
+//     let test_addr = Address::from_str("00000000000000000000000000000000deadbeef").unwrap();
+//
+//     let key = U256::from(420);
+//     let custom_value = U256::from(80085);
+//
+//     let mut db = CacheDB::new(EmptyDBTyped::<MockDBError>::new());
+//
+//     let mut state = State::builder().with_database(db).build();
+//
+//     // state.insert_not_existing(test_addr);
+//
+//     let mut evm = Evm::builder().with_db(&mut state).build();
+//
+//     let statediffs_accountstate = vec![TelosAccountStateTableRow {
+//         removed: false,
+//         address: test_addr,
+//         key,
+//         value: custom_value
+//     }];
+//
+//     compare_state_diffs(
+//         &mut evm,
+//         HashMap::default(),
+//         vec![],
+//         statediffs_accountstate.clone(),
+//         vec![],
+//         vec![],
+//         true
+//     );
+// }

--- a/crates/telos/node/tests/storage_compare.rs
+++ b/crates/telos/node/tests/storage_compare.rs
@@ -7,7 +7,7 @@ use antelope::api::v1::structs::{GetTableRowsParams, TableIndexType};
 use antelope::chain::name::Name;
 use antelope::name;
 use reqwest::Url;
-use telos_translator_rs::types::evm_types::AccountRow;
+use telos_translator_rs::types::evm_types::{AccountRow, AccountStateRow};
 
 #[tokio::test]
 pub async fn compare() {
@@ -31,7 +31,7 @@ pub async fn compare() {
     let mut count = 0;
 
     while has_more {
-        let mut query_params = GetTableRowsParams {
+        let query_params = GetTableRowsParams {
             code: name!("eosio.evm"),
             table: name!("account"),
             scope: None,
@@ -48,9 +48,9 @@ pub async fn compare() {
             has_more = lower_bound.is_some();
             for account_row in account_rows.rows {
                 let address = Address::from_slice(account_row.address.data.as_slice());
-                println!("Account: {:?}", address);
-                count += 1;
                 lower_bound = Some(TableIndexType::UINT64(account_row.index + 1));
+                compare_account(&account_row, &api_client, &provider, BlockId::from(evm_block_num as u64)).await;
+                count += 1;
             }
         } else {
             panic!("Failed to fetch account row");
@@ -60,16 +60,74 @@ pub async fn compare() {
     println!("Total account rows: {}", count);
 }
 
-async fn compare_account(account_row: AccountRow, provider: &ReqwestProvider, at_block: BlockId) {
+async fn compare_account(account_row: &AccountRow, api_client: &APIClient<DefaultProvider>, provider: &ReqwestProvider, at_block: BlockId) {
     let address = Address::from_slice(account_row.address.data.as_slice());
     let telos_balance = U256::from_be_slice(account_row.balance.data.as_slice());
-    let telos_nonce = U256::from(account_row.nonce);
-    let telos_code = account_row.code;
 
     let reth_balance = provider.get_balance(address).block_id(at_block).await.unwrap();
     let reth_nonce = provider.get_transaction_count(address).block_id(at_block).await.unwrap();
-    let reth_code = provider.get_code_at(address).block_id(at_block).await.unwrap();
+    let reth_code = provider.get_code_at(address).block_id(at_block).await.unwrap().to_vec();
 
+    let balance_missmatch = telos_balance != reth_balance;
+    let nonce_missmatch = account_row.nonce != reth_nonce;
+    let code_missmatch = account_row.code != reth_code;
 
-    println!("Account: {:?}", address);
+    if balance_missmatch || nonce_missmatch || code_missmatch {
+        println!("Account: {:?}", address);
+        println!("Telos balance: {:?}", telos_balance);
+        println!("Telos nonce: {:?}", account_row.nonce);
+        println!("Telos code: {:?}", account_row.code);
+        println!("Reth balance: {:?}", reth_balance);
+        println!("Reth nonce: {:?}", reth_nonce);
+        println!("Reth code: {:?}", reth_code);
+    }
+
+    compare_account_storage(account_row, api_client, provider, at_block).await;
+}
+
+async fn compare_account_storage(account_row: &AccountRow, api_client: &APIClient<DefaultProvider>, provider: &ReqwestProvider, at_block: BlockId) {
+    let address = Address::from_slice(account_row.address.data.as_slice());
+
+    let mut has_more = true;
+    let mut lower_bound = Some(TableIndexType::UINT64(0));
+
+    let mut count = 0;
+
+    while has_more {
+        let scope = if account_row.index == 0 {
+            Some(name!(""))
+        } else {
+            Some(Name::from_u64(account_row.index))
+        };
+        let query_params = GetTableRowsParams {
+            code: name!("eosio.evm"),
+            table: name!("accountstate"),
+            scope: Some(scope.unwrap()),
+            lower_bound,
+            upper_bound: None,
+            limit: Some(5000),
+            reverse: None,
+            index_position: None,
+            show_payer: None,
+        };
+        let account_state_rows = api_client.v1_chain.get_table_rows::<AccountStateRow>(query_params).await;
+        if let Ok(account_state_rows) = account_state_rows {
+            lower_bound = account_state_rows.next_key;
+            has_more = lower_bound.is_some();
+            for account_state_row in account_state_rows.rows {
+                let key = U256::from_be_slice(account_state_row.key.data.as_slice());
+                let telos_value = U256::from_be_slice(account_state_row.value.data.as_slice());
+                let reth_value = provider.get_storage_at(address, key).block_id(at_block).await.unwrap();
+                if telos_value != reth_value {
+                    println!("Storage key: {:?}", key);
+                    println!("Telos Storage value: {:?}", telos_value);
+                    println!("Reth storage value: {:?}", reth_value);
+                }
+                lower_bound = Some(TableIndexType::UINT64(account_state_row.index + 1));
+                count += 1;
+            }
+        } else {
+            panic!("Failed to fetch account state row");
+        }
+    }
 }

--- a/crates/telos/node/tests/storage_compare.rs
+++ b/crates/telos/node/tests/storage_compare.rs
@@ -1,0 +1,58 @@
+use alloy_provider::ProviderBuilder;
+use antelope::api::client::{APIClient, DefaultProvider};
+use antelope::api::v1::structs::{GetTableRowsParams, TableIndexType};
+use antelope::chain::name::Name;
+use antelope::name;
+use reqwest::Url;
+use telos_translator_rs::types::evm_types::AccountRow;
+
+// #[tokio::test]
+pub async fn compare() {
+    let evm_rpc = "http://localhost:8545";
+    // let telos_rpc = "http://192.168.0.20:8884";
+    let telos_rpc = "http://38.91.106.49:9000";
+    let block_delta = 57;
+
+    let api_client = APIClient::<DefaultProvider>::default_provider(telos_rpc.into(), Some(5)).unwrap();
+    let info = api_client.v1_chain.get_info().await.unwrap();
+
+
+    // let provider = ProviderBuilder::new()
+    //     .on_http(Url::from_str(evm_rpc).unwrap());
+
+    println!("Telos chain info: {:?}", info);
+    let evm_block_num = info.head_block_num - block_delta;
+
+    let mut has_more = true;
+    let mut lower_bound = Some(TableIndexType::UINT64(0));
+
+    let mut count = 0;
+
+    while has_more {
+        let mut query_params = GetTableRowsParams {
+            code: name!("eosio.evm"),
+            table: name!("account"),
+            scope: None,
+            lower_bound,
+            upper_bound: None,
+            limit: Some(5000),
+            reverse: None,
+            index_position: None,
+            show_payer: None,
+        };
+        let account_rows = api_client.v1_chain.get_table_rows::<AccountRow>(query_params).await;
+        if let Ok(account_rows) = account_rows {
+            lower_bound = account_rows.next_key;
+            has_more = lower_bound.is_some();
+            for account_row in account_rows.rows {
+                println!("Account: {:?}", account_row.address.as_string());
+                count += 1;
+                lower_bound = Some(TableIndexType::UINT64(account_row.index + 1));
+            }
+        } else {
+            panic!("Failed to fetch account row");
+        }
+    }
+
+    println!("Total account rows: {}", count);
+}

--- a/crates/telos/node/tests/storage_compare.rs
+++ b/crates/telos/node/tests/storage_compare.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, ProviderBuilder, ReqwestProvider};
+use alloy_rpc_types::BlockId;
 use antelope::api::client::{APIClient, DefaultProvider};
 use antelope::api::v1::structs::{GetTableRowsParams, TableIndexType};
 use antelope::chain::name::Name;
@@ -59,12 +60,16 @@ pub async fn compare() {
     println!("Total account rows: {}", count);
 }
 
-async fn compare_account(account_row: AccountRow, provider: &ReqwestProvider) {
+async fn compare_account(account_row: AccountRow, provider: &ReqwestProvider, at_block: BlockId) {
     let address = Address::from_slice(account_row.address.data.as_slice());
-    let telos_balance = U256::from(account_row.balance.data.as_slice());
+    let telos_balance = U256::from_be_slice(account_row.balance.data.as_slice());
     let telos_nonce = U256::from(account_row.nonce);
     let telos_code = account_row.code;
-    let reth_balance = provider.get_balance(address).await.unwrap();
+
+    let reth_balance = provider.get_balance(address).block_id(at_block).await.unwrap();
+    let reth_nonce = provider.get_transaction_count(address).block_id(at_block).await.unwrap();
+    let reth_code = provider.get_code_at(address).block_id(at_block).await.unwrap();
+
 
     println!("Account: {:?}", address);
 }

--- a/crates/telos/node/tests/storage_compare.rs
+++ b/crates/telos/node/tests/storage_compare.rs
@@ -5,9 +5,28 @@ use alloy_rpc_types::BlockId;
 use antelope::api::client::{APIClient, DefaultProvider};
 use antelope::api::v1::structs::{GetTableRowsParams, TableIndexType};
 use antelope::chain::name::Name;
-use antelope::name;
+use antelope::{name, StructPacker};
+use antelope::chain::{Encoder, Decoder, Packer};
+use antelope::chain::checksum::{Checksum160, Checksum256};
 use reqwest::Url;
-use telos_translator_rs::types::evm_types::{AccountRow, AccountStateRow};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, StructPacker)]
+pub struct AccountRow {
+    pub index: u64,
+    pub address: Checksum160,
+    pub account: Name,
+    pub nonce: u64,
+    pub code: Vec<u8>,
+    pub balance: Checksum256,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, StructPacker)]
+pub struct AccountStateRow {
+    pub index: u64,
+    pub key: Checksum256,
+    pub value: Checksum256,
+}
 
 #[tokio::test]
 pub async fn compare() {
@@ -22,8 +41,8 @@ pub async fn compare() {
     let provider = ProviderBuilder::new()
         .on_http(Url::from_str(evm_rpc).unwrap());
 
-    println!("Telos chain info: {:?}", info);
     let evm_block_num = info.head_block_num - block_delta;
+    println!("Telos EVM Block Number: {:?}", evm_block_num);
 
     let mut has_more = true;
     let mut lower_bound = Some(TableIndexType::UINT64(0));

--- a/crates/telos/node/tests/storage_compare.rs
+++ b/crates/telos/node/tests/storage_compare.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, StorageValue, U256};
 use alloy_provider::{Provider, ProviderBuilder, ReqwestProvider};
 use alloy_rpc_types::BlockId;
 use antelope::api::client::{APIClient, DefaultProvider};
@@ -30,9 +30,10 @@ pub struct AccountStateRow {
 
 #[tokio::test]
 pub async fn compare() {
-    let evm_rpc = "http://localhost:8545";
+    let evm_rpc = "http://38.91.106.49:9545";
+    // let evm_rpc = "http://localhost:8545";
     // let telos_rpc = "http://192.168.0.20:8884";
-    let telos_rpc = "http://38.91.106.49:9000";
+    let telos_rpc = "http://38.91.106.49:8899";
     let block_delta = 57;
 
     let api_client = APIClient::<DefaultProvider>::default_provider(telos_rpc.into(), Some(5)).unwrap();
@@ -135,12 +136,15 @@ async fn compare_account_storage(account_row: &AccountRow, api_client: &APIClien
             has_more = lower_bound.is_some();
             for account_state_row in account_state_rows.rows {
                 let key = U256::from_be_slice(account_state_row.key.data.as_slice());
-                let telos_value = U256::from_be_slice(account_state_row.value.data.as_slice());
-                let reth_value = provider.get_storage_at(address, key).block_id(at_block).await.unwrap();
+                let telos_value: U256 = U256::from_be_slice(account_state_row.value.data.as_slice());
+                let reth_value: U256 = provider.get_storage_at(address, key).block_id(at_block).await.unwrap();
                 if telos_value != reth_value {
-                    println!("Storage key: {:?}", key);
+                    println!("STORAGE MISMATCH!!!");
+                    println!("Storage account: {:?} with scope: {:?} and key: {:?}", address, scope.unwrap(), key);
                     println!("Telos Storage value: {:?}", telos_value);
-                    println!("Reth storage value: {:?}", reth_value);
+                    println!("Reth storage value:  {:?}", reth_value);
+                } else {
+                    println!(">>>>>>Storage match!!!!!<<<<<<");
                 }
                 lower_bound = Some(TableIndexType::UINT64(account_state_row.index + 1));
                 count += 1;

--- a/crates/telos/node/tests/storage_compare.rs
+++ b/crates/telos/node/tests/storage_compare.rs
@@ -49,6 +49,7 @@ impl MatchCounter {
     }
 
     pub fn print(&self) {
+        println!("Compared at block: {:?}", self.evm_block_number);
         println!("Mismatched accounts: {}", self.mismatched_accounts);
         println!("Mismatched storage rows: {}", self.mismatched_storage_rows);
         println!("Matching accounts: {}", self.total_accounts - self.mismatched_accounts);

--- a/crates/telos/rpc-engine-api/Cargo.toml
+++ b/crates/telos/rpc-engine-api/Cargo.toml
@@ -16,6 +16,7 @@ reth-storage-errors.workspace = true
 revm.workspace = true
 revm-primitives.workspace = true
 tracing.workspace = true
+sha2.workspace = true
 
 [lints]
 workspace = true

--- a/crates/telos/rpc-engine-api/src/compare.rs
+++ b/crates/telos/rpc-engine-api/src/compare.rs
@@ -231,9 +231,15 @@ where
         }
         if let Ok(revm_row) = revm_db.storage(row.address, row.key) {
             // The values should match, but if it is removed, then the revm value should be zero
-            if !(revm_row == row.value) && !(revm_row != U256::ZERO || row.removed == true) {
-                maybe_panic!(panic_mode, "Difference in value on revm storage, address: {:?}, key: {:?}, revm-value: {:?}, tevm-row: {:?}", row.address, row.key, revm_row, row);
-                state_override.override_storage(revm_db, row.address, row.key, row.value);
+            if revm_row != row.value {
+                if revm_row != U256::ZERO && row.removed == true {
+                    maybe_panic!(panic_mode, "Difference in value on revm storage, removed on Telos, non-ZERO on revm, address: {:?}, key: {:?}, revm-value: {:?}, tevm-row: {:?}", row.address, row.key, revm_row, row);
+                    state_override.override_storage(revm_db, row.address, row.key, U256::ZERO);
+                }
+                if row.removed == false {
+                    maybe_panic!(panic_mode, "Difference in value on revm storage, address: {:?}, key: {:?}, revm-value: {:?}, tevm-row: {:?}", row.address, row.key, revm_row, row);
+                    state_override.override_storage(revm_db, row.address, row.key, row.value);
+                }
             }
         } else {
             maybe_panic!(panic_mode, "Key was not found on revm storage, address: {:?}, key: {:?}",row.address,row.key);

--- a/crates/telos/rpc-engine-api/src/compare.rs
+++ b/crates/telos/rpc-engine-api/src/compare.rs
@@ -212,6 +212,9 @@ where
         }
     }
     for row in &statediffs_accountstate {
+        if let None = revm_db.cache.accounts.get_mut(&row.address) {
+            let _ = revm_db.load_cache_account(row.address);
+        }
         if let Ok(revm_row) = revm_db.storage(row.address, row.key) {
             // The values should match, but if it is removed, then the revm value should be zero
             if !(revm_row == row.value) && !(revm_row != U256::ZERO || row.removed == true) {

--- a/crates/telos/rpc-engine-api/src/compare.rs
+++ b/crates/telos/rpc-engine-api/src/compare.rs
@@ -29,7 +29,10 @@ impl StateOverride {
                 Ok(maybe_info) => {
                     maybe_info.unwrap_or_else(|| AccountInfo::default())
                 },
-                Err(_) => AccountInfo::default()
+                Err(_) => {
+                    status = AccountStatus::Created | AccountStatus::Touched;
+                    AccountInfo::default()
+                }
             };
 
             self.accounts.insert(address, Account {
@@ -156,6 +159,7 @@ where
         }
         // Skip if row is removed
         if row.removed {
+            // TODO: Does the Telos EVM contract ever remove account rows, or should this be a panic??
             continue
         }
         if let Ok(revm_row) = revm_db.basic(row.address) {
@@ -258,5 +262,5 @@ where
 
     state_override.apply(revm_db);
 
-    return true
+    true
 }

--- a/crates/telos/rpc/src/eth/mod.rs
+++ b/crates/telos/rpc/src/eth/mod.rs
@@ -26,7 +26,7 @@ use reth_provider::{
     BlockIdReader, BlockNumReader, BlockReaderIdExt, ChainSpecProvider, HeaderProvider,
     StageCheckpointReader, StateProviderFactory,
 };
-use reth_rpc::eth::{core::EthApiInner, DevSigner};
+use reth_rpc::eth::{core::EthApiInner, DevSigner, EthTxBuilder};
 use reth_rpc_eth_api::{
     helpers::{
         AddDevSigners, EthApiSpec, EthFees, EthSigner, EthState, LoadBlock, LoadFee, LoadState,
@@ -104,7 +104,7 @@ where
 {
     type Error = TelosEthApiError;
     type NetworkTypes = AnyNetwork;
-    type TransactionCompat = ();
+    type TransactionCompat = EthTxBuilder;
 }
 
 impl<N> EthApiSpec for TelosEthApi<N>


### PR DESCRIPTION
```
for each telos account row:
    1. telos row differs from revm_db.basic query
        a. revm row is some:
            - balance diff [DONE]
            - nonce diff [DONE]
            - code size/existence diff (if code len same content is not checked) [DONE]

        b. revm_db.basic returns none but telos row present
            - corresponding revm state diff found [DONE]
            - no revm state diff found [DONE]

    2. revm_db.basic finds the addr but row is empty [WIP: Cant seem to get revm_db.basic to return None]

for each telos account state row:
    1. telos row differs from revm_db.storage query
        - present but differs [WIP: Cant seem to edit storage, reth complains: "account is not loaded"]
        - key not present

for each revm state diff:
    1. if revm account info & prev info is present
        - find matching telos state diff
    2. if revm account info is empty
        - find matching telos state diff
    3. check all account storage keys and find them on telos state diff
```