### PR TITLE
Add remaining integration tests

### DIFF
--- a/crates/telos/node/tests/integration/test_resources_sandwich.rs
+++ b/crates/telos/node/tests/integration/test_resources_sandwich.rs
@@ -53,7 +53,7 @@ pub(crate) async fn test_2k_txs(
         let info = telos_client.v1_chain.get_info().await.unwrap();
         let nonce = get_nonce(&telos_client, &EOSIO_ADDR).await;
         let tx = multi_raw_eth_tx(
-            500,
+            100,
             &info,
             name!("eosio"),
             PermissionLevel::new(name!("eosio"), name!("active")),
@@ -73,11 +73,11 @@ pub(crate) async fn test_2k_txs(
 
         let result = telos_client.v1_chain.send_transaction(signed_tx).await.unwrap();
 
-        debug!("({}/{}) 500 txs in block {}", i + 1, total_batches, result.processed.block_num);
+        debug!("({}/{}) 100 txs in block {}", i + 1, total_batches, result.processed.block_num);
         tokio::time::sleep(Duration::from_secs(2)).await;
     }
 
     tokio::time::sleep(Duration::from_secs(3)).await;
     let last_nonce = get_nonce(&telos_client, &EOSIO_ADDR).await;
-    assert_eq!(last_nonce - start_nonce, 500 * total_batches);
+    assert_eq!(last_nonce - start_nonce, 100 * total_batches);
 }

--- a/crates/telos/node/tests/integration/test_resources_sandwich.rs
+++ b/crates/telos/node/tests/integration/test_resources_sandwich.rs
@@ -7,8 +7,10 @@ use antelope::api::client::{APIClient, DefaultProvider};
 use antelope::chain::action::PermissionLevel;
 use antelope::name;
 use antelope::chain::name::Name;
+use telos_translator_rs::types::evm_types::EvmContractConfigRow;
 use tracing::log::{debug, info};
-use crate::utils::cleos_evm::{doresources_sandwich, get_nonce, multi_raw_eth_tx, sign_native_tx, TestProvider, EOSIO_ADDR, EOSIO_PKEY, EOSIO_WALLET};
+use crate::setrevision_tx;
+use crate::utils::cleos_evm::{doresources_sandwich, get_evm_config, get_nonce, multi_raw_eth_tx, setrevision_sandwich, sign_native_tx, TestProvider, EOSIO_ADDR, EOSIO_PKEY, EOSIO_WALLET};
 
 pub(crate) async fn test_doresources_sandwich(
     reth_provider: &TestProvider,
@@ -80,4 +82,53 @@ pub(crate) async fn test_2k_txs(
     tokio::time::sleep(Duration::from_secs(3)).await;
     let last_nonce = get_nonce(&telos_client, &EOSIO_ADDR).await;
     assert_eq!(last_nonce - start_nonce, 100 * total_batches);
+}
+
+pub(crate) async fn test_setrevision_sandwich(
+    reth_provider: &TestProvider,
+    telos_client: &APIClient<DefaultProvider>
+) {
+    info!("test setrevision sandwich");
+    let info = telos_client.v1_chain.get_info().await.unwrap();
+    let nonce = reth_provider.get_transaction_count(EOSIO_ADDR.clone()).await.unwrap();
+    let chain_id = reth_provider.get_chain_id().await.unwrap();
+
+    // Get current gas price
+    let gas_price: u128 = reth_provider.get_gas_price().await.unwrap();
+
+    // Get current revision
+    let row: EvmContractConfigRow = get_evm_config(&telos_client).await;
+    let pre_revision_number = row.revision.value().unwrap().clone();
+
+    // Make a setrevision sandwich
+    let unsigned_sandwich = setrevision_sandwich(
+        &info, name!("eosio"), chain_id, nonce, gas_price, EOSIO_ADDR.clone()
+    ).await;
+    let sandwich_tx = sign_native_tx(&unsigned_sandwich, &info, &EOSIO_PKEY);
+    let result_tx = telos_client.v1_chain.send_transaction(sandwich_tx).await.unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let row: EvmContractConfigRow = get_evm_config(&telos_client).await;
+    let post_revision_number = row.revision.value().unwrap().clone();
+
+    let block = reth_provider.get_block_by_number(BlockNumberOrTag::Number(result_tx.processed.block_num - 57), true).await.unwrap().unwrap();
+    let txs: Vec<Transaction> = block.transactions.clone().into_transactions().collect();
+    let receipt_0 = reth_provider.get_transaction_receipt(txs[0].hash).await.unwrap().unwrap();
+    let receipt_1 = reth_provider.get_transaction_receipt(txs[1].hash).await.unwrap().unwrap();
+    assert_eq!(receipt_0.status(), true);
+    assert_eq!(receipt_1.status(), false);
+    assert_eq!(pre_revision_number, 1);
+    assert_eq!(post_revision_number, 0);
+
+    // Set revision back
+    let unsigned_rev_tx = setrevision_tx(&info, pre_revision_number);
+    let rev_tx = sign_native_tx(&unsigned_rev_tx, &info, &EOSIO_PKEY);
+    telos_client.v1_chain.send_transaction(rev_tx).await.unwrap();
+
+    // Get revision again
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let row: EvmContractConfigRow = get_evm_config(&telos_client).await;
+    let reset_revision_number = row.revision.value().unwrap().clone();
+    assert_eq!(reset_revision_number, 1);
+    
 }

--- a/crates/telos/node/tests/integration/test_tx_types.rs
+++ b/crates/telos/node/tests/integration/test_tx_types.rs
@@ -1,15 +1,27 @@
 use std::str::FromStr;
+use std::time::Duration;
 use alloy_consensus::{Signed, TxLegacy};
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{hex, keccak256, Address, Bytes, Signature, B256, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::{AccessList, AccessListItem, TransactionInput, TransactionRequest};
 use alloy_rpc_types::BlockNumberOrTag::Latest;
-use antelope::chain::checksum::Checksum256;
+use antelope::api::system::structs::CreateAccountParams;
+use antelope::api::system::SystemAPI;
+use antelope::api::v1::structs::{GetTableRowsParams, IndexPosition, TableIndexType};
+use antelope::chain::asset::Asset;
+use antelope::chain::authority::{Authority, KeyWeight};
+use antelope::chain::name::Name;
+use antelope::chain::private_key::PrivateKey;
+use antelope::name;
+use telos_translator_rs::types::evm_types::AccountRow;
+use telos_translator_rs::types::names::EOSIO;
+use crate::{APIClient, DefaultProvider, EOSIO_PKEY, sign_native_tx};
+use antelope::chain::checksum::{Checksum160, Checksum256};
 use num_bigint::{BigUint, ToBigUint};
 use telos_translator_rs::rlp::telos_rlp_decode::TelosTxDecodable;
 use tracing::log::info;
-use crate::utils::cleos_evm::{TestProvider, EOSIO_ADDR, EVM_USER_ADDR};
+use crate::utils::cleos_evm::{transfer_tx, TestProvider, EOSIO_ADDR, EVM_USER, EVM_USER_ADDR};
 
 // test_1559_tx tests sending eip1559 transaction that has max_priority_fee_per_gas and max_fee_per_gas set
 pub(crate) async fn test_1559_tx(provider: &TestProvider) {
@@ -337,4 +349,160 @@ fn make_unique_vrs(
     let r = U256::from_be_slice(r_biguint.to_bytes_be().as_slice());
     let s = U256::from_be_slice(&s_bytes);
     Signature::from_rs_and_parity(r, s, v).expect("Failed to create signature")
+}
+
+pub(crate) async fn test_deposit_to_address_zero(provider: &TestProvider, telos_client: &APIClient<DefaultProvider>) {
+    info!("test deposit to address zero");
+
+    // Get address zero balance before deposit
+    let address_zero_balance_before = provider.get_balance(Address::ZERO).await.unwrap();
+
+    let sys_api = SystemAPI::new(telos_client.clone());
+    let info = telos_client.v1_chain.get_info().await.unwrap();
+
+    // Create a test native account for deposit
+    let acc = Name::new_from_str("testdepzero1");
+    let acc_key = PrivateKey::from_str("5KKvUgsrcgJCCCqYkPgWCr4pzT6awYG7wn95XCcv142X1uStnxe", false).unwrap();
+
+    sys_api.create_account(CreateAccountParams{
+        creator: name!("eosio"),
+        name: acc,
+        stake_net: Asset::from_string("0.1000 TLOS"),
+        stake_cpu: Asset::from_string("0.1000 TLOS"),
+        ram_bytes: 10_000_000,
+        owner: Authority {threshold: 1, keys: vec![KeyWeight{key: acc_key.to_public(), weight: 1}], accounts: vec![], waits: vec![]},
+        active: Authority {threshold: 1, keys: vec![KeyWeight{key: acc_key.to_public(), weight: 1}], accounts: vec![], waits: vec![]},
+        transfer: true
+    }, EOSIO_PKEY.clone()).await.unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Transfer 0.0001 TLOS to the created test account
+    let tx = transfer_tx(&info, Name::from_u64(EOSIO), acc, 1, vec![]);
+    let signed_tx = sign_native_tx(&tx, &info, &EOSIO_PKEY);
+    telos_client.v1_chain.send_transaction(signed_tx).await.unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Do openwallet for address zero if it is not created yet
+    let query_params_account = GetTableRowsParams {
+        code: name!("eosio.evm"),
+        table: name!("account"),
+        scope: None,
+        lower_bound: Some(TableIndexType::CHECKSUM256(Checksum256::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap())),
+        upper_bound: Some(TableIndexType::CHECKSUM256(Checksum256::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap())),
+        limit: Some(1),
+        reverse: None,
+        index_position: Some(IndexPosition::SECONDARY),
+        show_payer: None,
+    };
+    let account_rows = telos_client.v1_chain.get_table_rows::<AccountRow>(query_params_account).await;
+    if let Ok(account_rows) = account_rows {
+        if account_rows.rows.len() != 1 || account_rows.rows[0].address != Checksum160::from_hex("0000000000000000000000000000000000000000").unwrap() {
+            // Address zero doesn't exist
+            let create_tx = crate::utils::cleos_evm::openwallet_tx(&info, Name::from_u64(EOSIO), Address::ZERO);
+            let signed_create_tx = sign_native_tx(&create_tx, &info, &EOSIO_PKEY);
+            telos_client.v1_chain.send_transaction(signed_create_tx).await.unwrap();
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+    
+    // Deposit 0.0001 TLOS to address zero
+    let memo = vec![48, 120, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48];
+    let tx = transfer_tx(&info, acc, name!("eosio.evm"), 1, memo);
+    let signed_tx = sign_native_tx(&tx, &info, &acc_key);
+    telos_client.v1_chain.send_transaction(signed_tx).await.unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Get address balance after deposit
+    let address_zero_balance_after = provider.get_balance(Address::ZERO).await.unwrap();
+
+    // Check if the balance is increased by 0.0001 TLOS
+    assert_eq!(address_zero_balance_after-address_zero_balance_before,U256::from(100000000000000_u64));
+}
+
+pub(crate) async fn test_deposit_lower_than_address_zero_balance(provider: &TestProvider, telos_client: &APIClient<DefaultProvider>) {
+    info!("test deposit lower than address zero balance");
+
+    // Get address zero balance before deposit
+    let address_zero_balance_before = provider.get_balance(Address::ZERO).await.unwrap();
+    let address_evm_user_balance_before = provider.get_balance(*EVM_USER_ADDR).await.unwrap();
+
+    let sys_api = SystemAPI::new(telos_client.clone());
+    let info = telos_client.v1_chain.get_info().await.unwrap();
+
+    // Create a test native account for deposit
+    let acc = Name::new_from_str("testdepzero2");
+    let acc_key = PrivateKey::from_str("5Hviu1MqZqBjrJ5EQyYBhn9xtQbxG8fYQWDX3ihN9n9D7DvXCqE", false).unwrap();
+
+    sys_api.create_account(CreateAccountParams{
+        creator: name!("eosio"),
+        name: acc,
+        stake_net: Asset::from_string("0.1000 TLOS"),
+        stake_cpu: Asset::from_string("0.1000 TLOS"),
+        ram_bytes: 10_000_000,
+        owner: Authority {threshold: 1, keys: vec![KeyWeight{key: acc_key.to_public(), weight: 1}], accounts: vec![], waits: vec![]},
+        active: Authority {threshold: 1, keys: vec![KeyWeight{key: acc_key.to_public(), weight: 1}], accounts: vec![], waits: vec![]},
+        transfer: true
+    }, EOSIO_PKEY.clone()).await.unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Transfer 0.0003 TLOS to the created test account
+    let tx = transfer_tx(&info, Name::from_u64(EOSIO), acc, 3, vec![]);
+    let signed_tx = sign_native_tx(&tx, &info, &EOSIO_PKEY);
+    telos_client.v1_chain.send_transaction(signed_tx).await.unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Do openwallet for address zero if it is not created yet
+    let query_params_account = GetTableRowsParams {
+        code: name!("eosio.evm"),
+        table: name!("account"),
+        scope: None,
+        lower_bound: Some(TableIndexType::CHECKSUM256(Checksum256::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap())),
+        upper_bound: Some(TableIndexType::CHECKSUM256(Checksum256::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap())),
+        limit: Some(1),
+        reverse: None,
+        index_position: Some(IndexPosition::SECONDARY),
+        show_payer: None,
+    };
+    let account_rows = telos_client.v1_chain.get_table_rows::<AccountRow>(query_params_account).await;
+    if let Ok(account_rows) = account_rows {
+        if account_rows.rows.len() != 1 || account_rows.rows[0].address != Checksum160::from_hex("0000000000000000000000000000000000000000").unwrap() {
+            // Address zero doesn't exist
+            let create_tx = crate::utils::cleos_evm::openwallet_tx(&info, Name::from_u64(EOSIO), Address::ZERO);
+            let signed_create_tx = sign_native_tx(&create_tx, &info, &EOSIO_PKEY);
+            telos_client.v1_chain.send_transaction(signed_create_tx).await.unwrap();
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+    
+    // Deposit 0.0002 TLOS to address zero
+    let memo = vec![48, 120, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48];
+    let tx = transfer_tx(&info, acc, name!("eosio.evm"), 2, memo);
+    let signed_tx = sign_native_tx(&tx, &info, &acc_key);
+    telos_client.v1_chain.send_transaction(signed_tx).await.unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Deposit 0.0001 TLOS (less than address zero balance) to another address
+    let tx = transfer_tx(&info, acc, name!("eosio.evm"), 1, EVM_USER_ADDR.to_string().into_bytes());
+    let signed_tx = sign_native_tx(&tx, &info, &acc_key);
+    telos_client.v1_chain.send_transaction(signed_tx).await.unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Get address balance after deposit
+    let address_zero_balance_after = provider.get_balance(Address::ZERO).await.unwrap();
+    let address_evm_user_balance_after = provider.get_balance(*EVM_USER_ADDR).await.unwrap();
+
+    // Check if the balance of address zero is increased by 0.0002 TLOS
+    assert_eq!(address_zero_balance_after-address_zero_balance_before,U256::from(200000000000000_u64));
+
+    // Check if the balance of evm user address is increased by 0.0001 TLOS
+    assert_eq!(address_evm_user_balance_after-address_evm_user_balance_before,U256::from(100000000000000_u64));
 }

--- a/crates/telos/node/tests/integration/test_tx_types.rs
+++ b/crates/telos/node/tests/integration/test_tx_types.rs
@@ -2,10 +2,12 @@ use std::str::FromStr;
 use std::time::Duration;
 use alloy_consensus::{Signed, TxLegacy};
 use alloy_network::TransactionBuilder;
-use alloy_primitives::{hex, keccak256, Address, Bytes, Signature, B256, U256};
+use alloy_primitives::{hex, keccak256, Address, Bytes, Signature, TxKind, B256, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::{AccessList, AccessListItem, TransactionInput, TransactionRequest};
 use alloy_rpc_types::BlockNumberOrTag::Latest;
+use alloy_sol_types::sol;
+use alloy_sol_types::sol_data::Bool;
 use antelope::api::system::structs::CreateAccountParams;
 use antelope::api::system::SystemAPI;
 use antelope::api::v1::structs::{GetTableRowsParams, IndexPosition, TableIndexType};
@@ -16,6 +18,7 @@ use antelope::chain::private_key::PrivateKey;
 use antelope::name;
 use telos_translator_rs::types::evm_types::AccountRow;
 use telos_translator_rs::types::names::EOSIO;
+use tracing::debug;
 use crate::{APIClient, DefaultProvider, EOSIO_PKEY, sign_native_tx};
 use antelope::chain::checksum::{Checksum160, Checksum256};
 use num_bigint::{BigUint, ToBigUint};
@@ -145,7 +148,7 @@ pub(crate) async fn test_wrong_nonce(provider: &TestProvider) {
     let err = tx_result.unwrap_err();
     assert_eq!(
         err.to_string(),
-        "server returned an error response: error code -32003: nonce too low: next nonce 8, tx nonce 0"
+        "server returned an error response: error code -32003: nonce too low: next nonce 10, tx nonce 0"
     )
 }
 
@@ -505,4 +508,140 @@ pub(crate) async fn test_deposit_lower_than_address_zero_balance(provider: &Test
 
     // Check if the balance of evm user address is increased by 0.0001 TLOS
     assert_eq!(address_evm_user_balance_after-address_evm_user_balance_before,U256::from(100000000000000_u64));
+}
+
+pub(crate) async fn test_get_account_bug(reth_provider: &TestProvider, telos_client: &APIClient<DefaultProvider>, expected_outcome: bool) {
+    info!("test get account bug, expected outcome: {}", expected_outcome);
+
+    let address1 = Address::random();
+    let address2 = Address::random();
+
+    let nonce = reth_provider.get_transaction_count(*EOSIO_ADDR).await.unwrap();
+    let chain_id = reth_provider.get_chain_id().await.unwrap();
+    let gas_price = reth_provider.get_gas_price().await.unwrap();
+
+    sol! {
+        #[sol(rpc, bytecode="608060405234801561001057600080fd5b50610226806100206000396000f3fe60806040526004361061001e5760003560e01c80633ab79a6f14610023575b600080fd5b61003d60048036038101906100389190610146565b61003f565b005b600060023461004e91906101bf565b90508273ffffffffffffffffffffffffffffffffffffffff166108fc829081150290604051600060405180830381858888f19350505050158015610096573d6000803e3d6000fd5b508173ffffffffffffffffffffffffffffffffffffffff166108fc829081150290604051600060405180830381858888f193505050501580156100dd573d6000803e3d6000fd5b50505050565b600080fd5b600073ffffffffffffffffffffffffffffffffffffffff82169050919050565b6000610113826100e8565b9050919050565b61012381610108565b811461012e57600080fd5b50565b6000813590506101408161011a565b92915050565b6000806040838503121561015d5761015c6100e3565b5b600061016b85828601610131565b925050602061017c85828601610131565b9150509250929050565b6000819050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601260045260246000fd5b60006101ca82610186565b91506101d583610186565b9250826101e5576101e4610190565b5b82820490509291505056fea264697066735822122075ae86f5524f94936eaa0251c4a94d92a5b02e384606fa1685efc83200e6143164736f6c63430008130033")]
+        contract SplitPayment {                
+            function splitTransfer(address payable recipient1, address payable recipient2) external payable {
+                uint256 half = msg.value / 2;
+                recipient1.transfer(half);
+                recipient2.transfer(half);
+            }
+        }
+    }
+
+    let legacy_tx = alloy_consensus::TxLegacy {
+        chain_id: Some(chain_id),
+        nonce,
+        gas_price: gas_price.into(),
+        gas_limit: 20_000_000,
+        to: TxKind::Create,
+        value: U256::ZERO,
+        input: SplitPayment::BYTECODE.to_vec().into(),
+    };
+
+    let legacy_tx_request = TransactionRequest {
+        from: Some(*EOSIO_ADDR),
+        to: Some(legacy_tx.to),
+        gas: Some(legacy_tx.gas_limit as u64),
+        gas_price: Some(legacy_tx.gas_price),
+        value: Some(legacy_tx.value),
+        input: TransactionInput::from(legacy_tx.input),
+        nonce: Some(legacy_tx.nonce),
+        chain_id: legacy_tx.chain_id,
+        ..Default::default()
+    };
+
+    let deploy_result = reth_provider.send_transaction(legacy_tx_request.clone()).await.unwrap();
+
+    let deploy_tx_hash = deploy_result.tx_hash();
+    debug!("Deployed contract with tx hash: {deploy_tx_hash}");
+    let receipt = deploy_result.get_receipt().await.unwrap();
+    debug!("Receipt: {:?}", receipt);
+    
+
+    let deployed_contract_address = receipt.contract_address.unwrap();
+    let split_payment = SplitPayment::new(deployed_contract_address, reth_provider.clone());
+
+    let legacy_tx_request = TransactionRequest::default()
+        .with_from(*EOSIO_ADDR)
+        .with_to(deployed_contract_address)
+        .with_gas_limit(20_000_000)
+        .with_gas_price(gas_price)
+        .with_input(split_payment.splitTransfer(address1, address2).calldata().clone())
+        .with_nonce(reth_provider.get_transaction_count(*EOSIO_ADDR).await.unwrap())
+        .with_chain_id(chain_id)
+        .with_value(U256::from_str("2").unwrap());
+
+    let call_result = reth_provider.send_transaction(legacy_tx_request.clone()).await.unwrap();
+
+    let call_tx_hash = call_result.tx_hash();
+    debug!("Called contract with tx hash: {call_tx_hash}");
+    let receipt = call_result.get_receipt().await.unwrap();
+    debug!("Receipt: {:?}", receipt);
+
+    let mut address1_256 = [0; 32];
+    address1_256[12..32].copy_from_slice(address1.as_slice());
+    let query_params_account = GetTableRowsParams {
+        code: name!("eosio.evm"),
+        table: name!("account"),
+        scope: None,
+        lower_bound: Some(TableIndexType::CHECKSUM256(Checksum256::from_bytes(&address1_256).unwrap())),
+        upper_bound: Some(TableIndexType::CHECKSUM256(Checksum256::from_bytes(&address1_256).unwrap())),
+        limit: Some(1),
+        reverse: None,
+        index_position: Some(IndexPosition::SECONDARY),
+        show_payer: None,
+    };
+    let account_rows = telos_client.v1_chain.get_table_rows::<AccountRow>(query_params_account).await;
+    if let Ok(account_rows) = account_rows {
+        assert_eq!(account_rows.rows.len(), 1);
+        assert_eq!(account_rows.rows[0].address, Checksum160::from_bytes(address1.as_slice()).unwrap());
+        if expected_outcome == true {
+            assert_eq!(account_rows.rows[0].balance, Checksum256::from_hex("0000000000000000000000000000000000000000000000000000000000000002").unwrap());
+        } else {
+            assert_eq!(account_rows.rows[0].balance, Checksum256::from_hex("0000000000000000000000000000000000000000000000000000000000000001").unwrap());
+        }
+    }
+
+    let mut address2_256 = [0; 32];
+    address2_256[12..32].copy_from_slice(address2.as_slice());
+    let query_params_account = GetTableRowsParams {
+        code: name!("eosio.evm"),
+        table: name!("account"),
+        scope: None,
+        lower_bound: Some(TableIndexType::CHECKSUM256(Checksum256::from_bytes(&address2_256).unwrap())),
+        upper_bound: Some(TableIndexType::CHECKSUM256(Checksum256::from_bytes(&address2_256).unwrap())),
+        limit: Some(1),
+        reverse: None,
+        index_position: Some(IndexPosition::SECONDARY),
+        show_payer: None,
+    };
+    let account_rows = telos_client.v1_chain.get_table_rows::<AccountRow>(query_params_account).await;
+    if let Ok(account_rows) = account_rows {        
+        if expected_outcome == true {
+            assert_eq!(account_rows.rows.len(), 0);
+        } else {
+            assert_eq!(account_rows.rows.len(), 1);
+            assert_eq!(account_rows.rows[0].address, Checksum160::from_bytes(address2.as_slice()).unwrap());
+            assert_eq!(account_rows.rows[0].balance, Checksum256::from_hex("0000000000000000000000000000000000000000000000000000000000000001").unwrap());
+        }
+    }
+
+    let address1_balance = reth_provider.get_balance(address1).await.unwrap();
+    let address2_balance = reth_provider.get_balance(address2).await.unwrap();
+
+    if expected_outcome == true {
+        assert_eq!(address1_balance, U256::from_str("2").unwrap());
+        assert_eq!(address2_balance, U256::ZERO);
+    } else {
+        assert_eq!(address1_balance, U256::from_str("1").unwrap());
+        assert_eq!(address2_balance, U256::from_str("1").unwrap());
+    }
+    
+
+}
+
+pub(crate) async fn test_delegate_call_bug(provider: &TestProvider, telos_client: &APIClient<DefaultProvider>, expected_outcome: Bool) {
 }

--- a/crates/telos/node/tests/integration/test_tx_types.rs
+++ b/crates/telos/node/tests/integration/test_tx_types.rs
@@ -148,7 +148,7 @@ pub(crate) async fn test_wrong_nonce(provider: &TestProvider) {
     let err = tx_result.unwrap_err();
     assert_eq!(
         err.to_string(),
-        "server returned an error response: error code -32003: nonce too low: next nonce 10, tx nonce 0"
+        "server returned an error response: error code -32003: nonce too low: next nonce 12, tx nonce 0"
     )
 }
 
@@ -643,5 +643,108 @@ pub(crate) async fn test_get_account_bug(reth_provider: &TestProvider, telos_cli
 
 }
 
-pub(crate) async fn test_delegate_call_bug(provider: &TestProvider, telos_client: &APIClient<DefaultProvider>, expected_outcome: Bool) {
+pub(crate) async fn test_delegate_call_bug(reth_provider: &TestProvider, telos_client: &APIClient<DefaultProvider>, expected_outcome: bool) {
+    info!("test delegate call bug, expected outcome: {}", expected_outcome);
+
+    let nonce = reth_provider.get_transaction_count(*EOSIO_ADDR).await.unwrap();
+    let chain_id = reth_provider.get_chain_id().await.unwrap();
+    let gas_price = reth_provider.get_gas_price().await.unwrap();
+
+    sol! {
+        #[sol(rpc, bytecode="608060405234801561001057600080fd5b506103e2806100206000396000f3fe6080604052600436106100295760003560e01c806312210e8a1461002e578063ac9650d814610038575b600080fd5b610036610054565b005b610052600480360381019061004d91906101e5565b61006a565b005b600047111561006857610067334761012b565b5b565b60005b828290508110156101265760003073ffffffffffffffffffffffffffffffffffffffff168484848181106100a4576100a3610232565b5b90506020028101906100b69190610270565b6040516100c4929190610312565b600060405180830381855af49150503d80600081146100ff576040519150601f19603f3d011682016040523d82523d6000602084013e610104565b606091505b505090508061011257600080fd5b50808061011e90610364565b91505061006d565b505050565b8173ffffffffffffffffffffffffffffffffffffffff166108fc829081150290604051600060405180830381858888f19350505050158015610171573d6000803e3d6000fd5b505050565b600080fd5b600080fd5b600080fd5b600080fd5b600080fd5b60008083601f8401126101a5576101a4610180565b5b8235905067ffffffffffffffff8111156101c2576101c1610185565b5b6020830191508360208202830111156101de576101dd61018a565b5b9250929050565b600080602083850312156101fc576101fb610176565b5b600083013567ffffffffffffffff81111561021a5761021961017b565b5b6102268582860161018f565b92509250509250929050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603260045260246000fd5b600080fd5b600080fd5b600080fd5b6000808335600160200384360303811261028d5761028c610261565b5b80840192508235915067ffffffffffffffff8211156102af576102ae610266565b5b6020830192506001820236038313156102cb576102ca61026b565b5b509250929050565b600081905092915050565b82818337600083830152505050565b60006102f983856102d3565b93506103068385846102de565b82840190509392505050565b600061031f8284866102ed565b91508190509392505050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b6000819050919050565b600061036f8261035a565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff82036103a1576103a061032b565b5b60018201905091905056fea26469706673582212204b3df5d960eccea2768412c0b88c37173c20373075cf79113f28a5fb85e6d0a264736f6c63430008130033")]
+        contract MulticallTest {
+            function multicall(bytes[] calldata data) external payable {
+                for (uint256 i = 0; i < data.length; i++) {
+                    (bool success, ) = address(this).delegatecall(data[i]);
+                    require(success, "");
+                }
+            }
+        
+            function safeTransferETH(address to, uint256 value) internal {
+                payable(to).transfer(value);
+            }
+        
+            function refundETH() external payable {
+                if (address(this).balance > 0) safeTransferETH(msg.sender, address(this).balance);
+            }
+        }
+    }
+
+    let legacy_tx = alloy_consensus::TxLegacy {
+        chain_id: Some(chain_id),
+        nonce,
+        gas_price: gas_price.into(),
+        gas_limit: 20_000_000,
+        to: TxKind::Create,
+        value: U256::ZERO,
+        input: MulticallTest::BYTECODE.to_vec().into(),
+    };
+
+    let legacy_tx_request = TransactionRequest {
+        from: Some(*EOSIO_ADDR),
+        to: Some(legacy_tx.to),
+        gas: Some(legacy_tx.gas_limit as u64),
+        gas_price: Some(legacy_tx.gas_price),
+        value: Some(legacy_tx.value),
+        input: TransactionInput::from(legacy_tx.input),
+        nonce: Some(legacy_tx.nonce),
+        chain_id: legacy_tx.chain_id,
+        ..Default::default()
+    };
+
+    let deploy_result = reth_provider.send_transaction(legacy_tx_request.clone()).await.unwrap();
+
+    let deploy_tx_hash = deploy_result.tx_hash().clone();
+    debug!("Deployed contract with tx hash: {deploy_tx_hash}");
+    let receipt = deploy_result.get_receipt().await.unwrap();
+    debug!("Receipt: {:?}", receipt);
+
+    let deployed_contract_address = receipt.contract_address.unwrap();
+    let multicall_test = MulticallTest::new(deployed_contract_address, reth_provider.clone());
+
+    let legacy_tx_request = TransactionRequest::default()
+        .with_from(*EOSIO_ADDR)
+        .with_to(deployed_contract_address)
+        .with_gas_limit(20_000_000)
+        .with_gas_price(gas_price)
+        .with_input(multicall_test.multicall(vec![multicall_test.refundETH().calldata().clone(),multicall_test.refundETH().calldata().clone()]).calldata().clone())
+        .with_nonce(reth_provider.get_transaction_count(*EOSIO_ADDR).await.unwrap())
+        .with_chain_id(chain_id)
+        .with_value(U256::from_str("2").unwrap());
+
+    let call_result = reth_provider.send_transaction(legacy_tx_request.clone()).await.unwrap();
+
+    let call_tx_hash = call_result.tx_hash().clone();
+    debug!("Called contract with tx hash: {call_tx_hash}");
+    let receipt = call_result.get_receipt().await.unwrap();
+    debug!("Receipt: {:?}", receipt);
+
+    if expected_outcome == true {
+        assert_eq!(receipt.status(), false);
+        assert_eq!(receipt.gas_used, 31427);
+    } else {
+        assert_eq!(receipt.status(), true);
+        assert_eq!(receipt.gas_used, 31750);
+    }
+
+    let mut address_256 = [0; 32];
+    address_256[12..32].copy_from_slice(EOSIO_ADDR.as_slice());
+    let query_params_account = GetTableRowsParams {
+        code: name!("eosio.evm"),
+        table: name!("account"),
+        scope: None,
+        lower_bound: Some(TableIndexType::CHECKSUM256(Checksum256::from_bytes(&address_256).unwrap())),
+        upper_bound: Some(TableIndexType::CHECKSUM256(Checksum256::from_bytes(&address_256).unwrap())),
+        limit: Some(1),
+        reverse: None,
+        index_position: Some(IndexPosition::SECONDARY),
+        show_payer: None,
+    };
+    let account_rows = telos_client.v1_chain.get_table_rows::<AccountRow>(query_params_account).await;
+    if let Ok(account_rows) = account_rows {
+        assert_eq!(account_rows.rows.len(), 1);
+        assert_eq!(account_rows.rows[0].address, Checksum160::from_bytes(EOSIO_ADDR.as_slice()).unwrap());
+        assert_eq!(account_rows.rows[0].balance, Checksum256::from_bytes(&reth_provider.get_balance(*EOSIO_ADDR).await.unwrap().to_be_bytes_vec()).unwrap());
+    }
+
 }

--- a/crates/telos/node/tests/integration/test_tx_types.rs
+++ b/crates/telos/node/tests/integration/test_tx_types.rs
@@ -222,6 +222,42 @@ fn tx_trailing_empty_values() -> eyre::Result<Signed<TxLegacy>> {
     Ok(TxLegacy::decode_telos_signed_fields(&mut &byte_array[..], Some(sig))?)
 }
 
+pub(crate) async fn test_incorrect_rlp2() {
+    info!("test incorrect rlp 2");
+    // This tx has zero bytes at the begining of the value field
+    let byte_array1: [u8; 110] = [
+        248, 108, 128, 133, 145, 118, 175, 139, 189, 130, 102, 138, 148, 214, 158,
+        75, 228, 231, 154, 220, 229, 255, 60, 247, 180, 252, 44, 195, 128, 100, 144,
+        161, 226, 136, 0, 0, 91, 89, 211, 178, 0, 0, 128, 116, 160, 233, 104, 245,
+        146, 128, 22, 167, 66, 240, 231, 190, 223, 155, 110, 74, 146, 242, 35, 55,
+        159, 19, 54, 28, 159, 204, 118, 79, 178, 79, 4, 206, 34, 160, 46, 106, 147,
+        128, 181, 16, 24, 179, 70, 133, 148, 83, 112, 28, 214, 55, 13, 22, 254,
+        33, 156, 138, 218, 222, 185, 184, 27, 126, 66, 57, 225, 171,
+    ];
+    let byte_array1_result_regular = TxLegacy::decode_signed_fields(&mut &byte_array1[..]);
+    // It should fail in being decoded in regular RLP decode function
+    assert!(byte_array1_result_regular.is_err());
+    let byte_array1_result_telos = TxLegacy::decode_telos_signed_fields(&mut &byte_array1[..], None);
+    // But it should succeed in being decoded in Telos custom RLP decode function
+    assert!(byte_array1_result_telos.is_ok());
+
+    // This tx has extra bytes at the end of transaction
+    let byte_array2: [u8; 118] = [
+        248, 108, 128, 133, 145, 118, 175, 139, 189, 130, 102, 138, 148, 214, 158,
+        75, 228, 231, 154, 220, 229, 255, 60, 247, 180, 252, 44, 195, 128, 100,
+        144, 161, 226, 136, 6, 240, 91, 89, 211, 178, 0, 0, 128, 116, 160, 233,
+        104, 245, 146, 128, 22, 167, 66, 240, 231, 190, 223, 155, 110, 74, 146,
+        242, 35, 55, 159, 19, 54, 28, 159, 204, 118, 79, 178, 79, 4, 206, 34, 160,
+        46, 106, 147, 128, 181, 16, 24, 179, 70, 133, 148, 83, 112, 28, 214, 55,
+        13, 22, 254, 33, 156, 138, 218, 222, 185, 184, 27, 126, 66, 57, 225, 171,
+        1, 2, 3, 4, 5, 6, 7, 8,
+    ];
+    let byte_array2_result = TxLegacy::decode_telos_signed_fields(&mut &byte_array2[..], None);
+    // It should succeed in being decoded in Telos custom RLP decode function
+    assert!(byte_array2_result.is_ok());
+
+}
+
 pub(crate) async fn test_unsigned_trx(provider: &TestProvider) {
     info!("test unsigned trx");
     let chain_id = Some(provider.get_chain_id().await.unwrap());

--- a/crates/telos/node/tests/integration_main.rs
+++ b/crates/telos/node/tests/integration_main.rs
@@ -25,7 +25,7 @@ use crate::integration::test_blocknum::test_blocknum_onchain;
 use crate::integration::test_nonce::test_evm_address_nonce;
 use crate::integration::test_resources_sandwich::{test_2k_txs, test_doresources_sandwich};
 use crate::integration::test_revision::test_revision;
-use crate::integration::test_tx_types::{test_1559_tx, test_2930_tx, test_double_approve_erc20, test_high_nonce, test_incorrect_rlp, test_signed_trx, test_unsigned_trx, test_unsigned_trx2, test_wrong_nonce};
+use crate::integration::test_tx_types::{test_1559_tx, test_2930_tx, test_double_approve_erc20, test_high_nonce, test_incorrect_rlp, test_signed_trx, test_unsigned_trx, test_unsigned_trx2, test_wrong_nonce, test_deposit_to_address_zero, test_deposit_lower_than_address_zero_balance};
 use crate::utils::cleos_evm::{setrevision_tx, sign_native_tx, TestProvider, EOSIO_PKEY, EOSIO_WALLET};
 
 #[tokio::test]
@@ -162,6 +162,8 @@ async fn run_rev_1_tests(reth_provider: &TestProvider, telos_api: &APIClient<Def
     test_signed_trx(&reth_provider).await;
     test_wrong_nonce(&reth_provider).await;
     test_high_nonce(&reth_provider).await;
+    test_deposit_to_address_zero(&reth_provider, &telos_api).await;
+    test_deposit_lower_than_address_zero_balance(&reth_provider, &telos_api).await;
 
     test_bad_memo(&reth_provider, &telos_api).await;
 

--- a/crates/telos/node/tests/integration_main.rs
+++ b/crates/telos/node/tests/integration_main.rs
@@ -7,7 +7,7 @@ use std::env;
 use std::time::Duration;
 use alloy_provider::{Provider, ProviderBuilder};
 use antelope::api::client::{APIClient, DefaultProvider};
-use integration::test_tx_types::test_get_account_bug;
+use integration::test_tx_types::{test_delegate_call_bug, test_get_account_bug};
 use reqwest::Url;
 use telos_translator_rs::block::TelosEVMBlock;
 use tokio::sync::mpsc;
@@ -150,6 +150,7 @@ async fn run_rev_0_tests(reth_provider: &TestProvider, telos_api: &APIClient<Def
     test_revision(&telos_api, None).await;
     test_evm_address_nonce(&reth_provider, &telos_api).await;
     test_get_account_bug(&reth_provider, &telos_api, true).await;
+    test_delegate_call_bug(&reth_provider, &telos_api, true).await;
 }
 
 async fn run_rev_1_tests(reth_provider: &TestProvider, telos_api: &APIClient<DefaultProvider>) {
@@ -168,6 +169,7 @@ async fn run_rev_1_tests(reth_provider: &TestProvider, telos_api: &APIClient<Def
     test_deposit_lower_than_address_zero_balance(&reth_provider, &telos_api).await;
 
     test_get_account_bug(&reth_provider, &telos_api, false).await;
+    test_delegate_call_bug(&reth_provider, &telos_api, false).await;
 
     test_bad_memo(&reth_provider, &telos_api).await;
 

--- a/crates/telos/node/tests/integration_main.rs
+++ b/crates/telos/node/tests/integration_main.rs
@@ -7,6 +7,7 @@ use std::env;
 use std::time::Duration;
 use alloy_provider::{Provider, ProviderBuilder};
 use antelope::api::client::{APIClient, DefaultProvider};
+use integration::test_tx_types::test_get_account_bug;
 use reqwest::Url;
 use telos_translator_rs::block::TelosEVMBlock;
 use tokio::sync::mpsc;
@@ -148,6 +149,7 @@ async fn integration_test_entrypoint() {
 async fn run_rev_0_tests(reth_provider: &TestProvider, telos_api: &APIClient<DefaultProvider>) {
     test_revision(&telos_api, None).await;
     test_evm_address_nonce(&reth_provider, &telos_api).await;
+    test_get_account_bug(&reth_provider, &telos_api, true).await;
 }
 
 async fn run_rev_1_tests(reth_provider: &TestProvider, telos_api: &APIClient<DefaultProvider>) {
@@ -164,6 +166,8 @@ async fn run_rev_1_tests(reth_provider: &TestProvider, telos_api: &APIClient<Def
     test_high_nonce(&reth_provider).await;
     test_deposit_to_address_zero(&reth_provider, &telos_api).await;
     test_deposit_lower_than_address_zero_balance(&reth_provider, &telos_api).await;
+
+    test_get_account_bug(&reth_provider, &telos_api, false).await;
 
     test_bad_memo(&reth_provider, &telos_api).await;
 

--- a/crates/telos/node/tests/integration_main.rs
+++ b/crates/telos/node/tests/integration_main.rs
@@ -26,7 +26,7 @@ use crate::integration::test_blocknum::test_blocknum_onchain;
 use crate::integration::test_nonce::test_evm_address_nonce;
 use crate::integration::test_resources_sandwich::{test_2k_txs, test_doresources_sandwich};
 use crate::integration::test_revision::test_revision;
-use crate::integration::test_tx_types::{test_1559_tx, test_2930_tx, test_double_approve_erc20, test_high_nonce, test_incorrect_rlp, test_signed_trx, test_unsigned_trx, test_unsigned_trx2, test_wrong_nonce, test_deposit_to_address_zero, test_deposit_lower_than_address_zero_balance};
+use crate::integration::test_tx_types::{test_1559_tx, test_2930_tx, test_double_approve_erc20, test_high_nonce, test_incorrect_rlp, test_incorrect_rlp2, test_signed_trx, test_unsigned_trx, test_unsigned_trx2, test_wrong_nonce, test_deposit_to_address_zero, test_deposit_lower_than_address_zero_balance};
 use crate::utils::cleos_evm::{setrevision_tx, sign_native_tx, TestProvider, EOSIO_PKEY, EOSIO_WALLET};
 
 #[tokio::test]
@@ -160,6 +160,7 @@ async fn run_rev_1_tests(reth_provider: &TestProvider, telos_api: &APIClient<Def
     test_2930_tx(&reth_provider).await;
     test_double_approve_erc20(&reth_provider).await;
     test_incorrect_rlp(&reth_provider).await;
+    test_incorrect_rlp2().await;
     test_unsigned_trx(&reth_provider).await;
     test_unsigned_trx2(&reth_provider).await;
     test_signed_trx(&reth_provider).await;

--- a/crates/telos/node/tests/integration_main.rs
+++ b/crates/telos/node/tests/integration_main.rs
@@ -24,7 +24,7 @@ mod utils;
 use crate::integration::test_bad_memo::test_bad_memo;
 use crate::integration::test_blocknum::test_blocknum_onchain;
 use crate::integration::test_nonce::test_evm_address_nonce;
-use crate::integration::test_resources_sandwich::{test_2k_txs, test_doresources_sandwich};
+use crate::integration::test_resources_sandwich::{test_2k_txs, test_doresources_sandwich, test_setrevision_sandwich};
 use crate::integration::test_revision::test_revision;
 use crate::integration::test_tx_types::{test_1559_tx, test_2930_tx, test_double_approve_erc20, test_high_nonce, test_incorrect_rlp, test_incorrect_rlp2, test_signed_trx, test_unsigned_trx, test_unsigned_trx2, test_wrong_nonce, test_deposit_to_address_zero, test_deposit_lower_than_address_zero_balance};
 use crate::utils::cleos_evm::{setrevision_tx, sign_native_tx, TestProvider, EOSIO_PKEY, EOSIO_WALLET};
@@ -177,4 +177,5 @@ async fn run_rev_1_tests(reth_provider: &TestProvider, telos_api: &APIClient<Def
     // 2k txs needed to seed fees for resource sandwich
     test_2k_txs(&reth_provider, &telos_api).await;
     test_doresources_sandwich(&reth_provider, &telos_api).await;
+    test_setrevision_sandwich(&reth_provider, &telos_api).await;
 }

--- a/crates/telos/node/tests/utils/cleos_evm.rs
+++ b/crates/telos/node/tests/utils/cleos_evm.rs
@@ -1,10 +1,11 @@
 use std::str::FromStr;
 use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, TxKind, U256};
 use alloy_primitives::bytes::BytesMut;
 use alloy_primitives::private::alloy_rlp::Encodable;
 use alloy_provider::fillers::{FillProvider, JoinFill, WalletFiller};
 use alloy_provider::{Identity, ReqwestProvider};
+use alloy_sol_types::sol;
 use antelope::api::v1::structs::{GetInfoResponse, GetTableRowsParams, IndexPosition, TableIndexType};
 use antelope::chain::action::{Action, PermissionLevel};
 use antelope::chain::checksum::{Checksum160, Checksum256};
@@ -14,14 +15,14 @@ use antelope::chain::Packer;
 use antelope::{name, StructPacker};
 use antelope::serializer::{Decoder, Encoder};
 use antelope::chain::private_key::PrivateKey;
-use alloy_rpc_types::TransactionRequest;
+use alloy_rpc_types::{TransactionInput, TransactionRequest};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_transport_http::Http;
 use antelope::api::client::{APIClient, DefaultProvider};
 use antelope::chain::asset::{Asset, Symbol};
 use lazy_static::lazy_static;
 use reqwest::Client;
-use telos_translator_rs::types::evm_types::{AccountRow, EvmContractConfigRow};
+use telos_translator_rs::types::evm_types::{AccountRow, EvmContractConfigRow, SetRevisionAction};
 
 // reth provider type
 pub(crate) type TestProvider = FillProvider<JoinFill<Identity, WalletFiller<EthereumWallet>>, ReqwestProvider, Http<Client>, Ethereum>;
@@ -455,6 +456,139 @@ pub(crate) async fn doresources_sandwich(
         header: trx_header,
         context_free_actions: vec![],
         actions: vec![pre_tx, set_res_action, res_action, post_tx],
+        extension: vec![],
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) async fn setrevision_sandwich(
+    info: &GetInfoResponse,
+    ram_payer: Name,
+    chain_id: u64,
+    start_nonce: u64,
+    gas_price: u128,
+    address: Address,
+) -> Transaction {
+    let trx_header = info.get_transaction_header(90);
+
+    sol! {
+        #[sol(rpc, bytecode="608060405234801561000f575f80fd5b505f805f555060ac806100215f395ff3fe6080604052348015600e575f80fd5b50600436106026575f3560e01c80636d619daa14602a575b5f80fd5b60306044565b604051603b9190605f565b60405180910390f35b5f5481565b5f819050919050565b6059816049565b82525050565b5f60208201905060705f8301846052565b9291505056fea26469706673582212205399ccd43cebd796d856269bea7d6b15156d118f97662b3f5e24089a290c6d6e64736f6c63430008160033")]
+        contract Push0Test {
+            uint256 public storedValue;
+        
+            constructor() {
+                assembly {
+                    // Use bytecode injection to insert PUSH0 manually
+                    let zero := 0
+                    sstore(storedValue.slot, zero)
+                }
+            }
+        }
+    }
+
+    let legacy_tx = alloy_consensus::TxLegacy {
+        chain_id: Some(chain_id),
+        nonce: start_nonce,
+        gas_price: gas_price,
+        gas_limit: 20_000_000,
+        to: TxKind::Create,
+        value: U256::ZERO,
+        input: Push0Test::BYTECODE.to_vec().into(),
+    };
+
+    let eth_pre_tx_typed = TransactionRequest {
+        from: Some(alloy_primitives::Address(*address)),
+        to: Some(legacy_tx.to),
+        gas: Some(legacy_tx.gas_limit as u64),
+        gas_price: Some(legacy_tx.gas_price),
+        value: Some(legacy_tx.value),
+        input: TransactionInput::from(legacy_tx.input.clone()),
+        nonce: Some(legacy_tx.nonce),
+        chain_id: legacy_tx.chain_id,
+        ..Default::default()
+    };
+
+    let eth_pre_tx_envelope = eth_pre_tx_typed.clone().build(&EOSIO_WALLET.clone()).await.unwrap();
+    let mut eth_pre_tx_raw_buf = BytesMut::new();
+    eth_pre_tx_envelope.encode(&mut eth_pre_tx_raw_buf);
+
+    let eth_pre_tx_raw: Vec<u8> = eth_pre_tx_raw_buf.to_vec();
+
+    // generate native transaction
+    #[derive(Clone, Eq, PartialEq, Default, StructPacker)]
+    struct Raw {
+        ram_payer: Name,
+        tx: Vec<u8>,
+        estimate_gas: bool,
+        sender: Option<Checksum160>,
+    }
+
+    #[derive(Clone, Eq, PartialEq, Default, StructPacker)]
+    struct SetResourcesParams {
+        gas_per_byte: u64,
+        target_free: u64,
+        min_buy: u64,
+        fee_transfer_pct: u64,
+    }
+
+    let pre_raw_data = Raw {
+        ram_payer,
+        tx: eth_pre_tx_raw,
+        estimate_gas: false,
+        sender: None,
+    };
+
+    let pre_tx = Action::new_ex(
+        name!("eosio.evm"),
+        name!("raw"),
+        vec![PermissionLevel::new(name!("eosio"), name!("active"))],
+        pre_raw_data,
+    );
+
+    let set_rev_action = Action::new(
+        name!("eosio.evm"),
+        name!("setrevision"),
+        PermissionLevel::new(name!("eosio.evm"), name!("active")),
+        SetRevisionAction {
+            new_revision: 0,
+        },
+    );
+
+    let eth_post_tx_typed = TransactionRequest {
+        from: Some(alloy_primitives::Address(*address)),
+        to: Some(legacy_tx.to),
+        gas: Some(legacy_tx.gas_limit as u64),
+        gas_price: Some(legacy_tx.gas_price),
+        value: Some(legacy_tx.value),
+        input: TransactionInput::from(legacy_tx.input.clone()),
+        nonce: Some(legacy_tx.nonce+1),
+        chain_id: legacy_tx.chain_id,
+        ..Default::default()
+    };
+    let eth_post_tx_envelope = eth_post_tx_typed.build(&EOSIO_WALLET.clone()).await.unwrap();
+    let mut eth_post_tx_raw_buf = BytesMut::new();
+    eth_post_tx_envelope.encode(&mut eth_post_tx_raw_buf);
+
+    let eth_post_tx_raw: Vec<u8> = eth_post_tx_raw_buf.to_vec();
+
+    let post_raw_data = Raw {
+        ram_payer,
+        tx: eth_post_tx_raw,
+        estimate_gas: false,
+        sender: None,
+    };
+
+    let post_tx = Action::new_ex(
+        name!("eosio.evm"),
+        name!("raw"),
+        vec![PermissionLevel::new(name!("eosio"), name!("active"))],
+        post_raw_data,
+    );
+
+    Transaction {
+        header: trx_header,
+        context_free_actions: vec![],
+        actions: vec![pre_tx, set_rev_action, post_tx],
         extension: vec![],
     }
 }


### PR DESCRIPTION
This PR addresses these two tests for integration test #23:

- Withdraw when ZERO has adequate balance (@aamirpashaa this was our second issue on testnet related to ZERO address balance, need to figure out how to replicate the issue in our integration test)
- Deposit to ZERO address, ensure reth balance is correct after the transaction
- Create test that exercises our bugs from revision 0 and assert they still fail (get account bug and delegate call bug)
- Send incorrect RLP encoded transactions (trailing zero values, the value field as leading zero, etc..)
- Add a setrevision sandwich so that a setrevision function call is between two identical transactions and should change the behavior of EVM in terms of execution results.