### PR TITLE
fix(rpc): improve error messages for insufficient funds and duplicate txs

### DIFF
--- a/crates/telos/rpc/src/eth/telos_client.rs
+++ b/crates/telos/rpc/src/eth/telos_client.rs
@@ -19,7 +19,7 @@ use tracing::{debug, error, warn};
 use backoff::Exponential;
 use reth_primitives::revm_primitives::bitvec::macros::internal::funty::Fundamental;
 use reth_rpc_eth_types::error::EthResult;
-use reth_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
+use reth_rpc_eth_types::{EthApiError, RpcInvalidTransactionError, RpcPoolError};
 
 #[derive(Debug)]
 struct TelosError(ClientError<SendTransactionResponse2Error>);
@@ -55,6 +55,18 @@ fn parse_error_message(message: String) -> Option<EthApiError> {
     if message.contains("Transaction gas price") {
         // TODO: gas to high
         return Some(EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooLow));
+    }
+    // Insufficient funds: eosio.evm returns "Sender balance too low to pay for gas"
+    if message.contains("balance too low") {
+        return Some(EthApiError::InvalidTransaction(
+            RpcInvalidTransactionError::InsufficientFundsForTransfer,
+        ));
+    }
+    // Already known: eosio.evm returns this when a duplicate tx is submitted
+    if message.contains("already known") || message.contains("duplicate") {
+        return Some(EthApiError::PoolError(
+            RpcPoolError::Invalid(RpcInvalidTransactionError::AlreadyKnown),
+        ));
     }
     if !message.contains("incorrect nonce") {
         return Some(EthApiError::EvmCustom(message.to_string()));


### PR DESCRIPTION
## Problem

The Telos RPC returns a generic `Revm error: Error sending transaction to Telos` for multiple distinct error conditions from the eosio.evm contract. This makes it extremely difficult for developers to diagnose deployment and transaction issues.

### Real-world impact

A developer deploying a LayerZero OFT contract on testnet via Hardhat received:
```
ProviderError: Revm error: Error sending transaction to Telos
```

This tells the developer nothing. The actual cause was insufficient funds for gas, but because the error was generic, the developer spent hours trying different gas settings, clearing caches, and switching tools.

## Root Cause

`parse_error_message()` in `telos_client.rs` only handles 3 error patterns:
1. Invalid packed transaction → decode error
2. Transaction gas price → gas too low  
3. Incorrect nonce → nonce errors

Everything else falls through to `EvmCustom(message)` → `"Revm error: <msg>"`

## Fix

Add proper error parsing for two common cases observed in production logs on testnet nodes:

### 1. Insufficient funds
eosio.evm returns: `"Invalid Transaction: Sender balance too low to pay for gas"`

**Before:** `Revm error: Error sending transaction to Telos`  
**After:** `insufficient funds for transfer`

### 2. Duplicate transactions  
When the same tx bytes are submitted twice (common with Hardhat retries)

**Before:** `Revm error: Error sending transaction to Telos`  
**After:** `already known`

## Evidence

Error strings confirmed from actual reth logs on rpc9 testnet node:
```
data: Object {"s": String("Invalid Transaction: Sender balance too low to pay for gas")}
```

## Testing

Reproduced the insufficient funds scenario by deploying a LayerZero OFT contract with a wallet that had less TLOS than `gasPrice × gasLimit`. Confirmed the generic error. The fix maps these to standard EVM error types that Hardhat, Foundry, and ethers.js understand.