### PR TITLE
feat: enable London, Shanghai, and Cancun hardforks for Telos EVM

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -146,6 +146,9 @@ pub static TEVMMAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
                 (EthereumHardfork::Istanbul, ForkCondition::Block(0)),
                 (EthereumHardfork::MuirGlacier, ForkCondition::Block(0)),
                 (EthereumHardfork::Berlin, ForkCondition::Block(0)),
+                (EthereumHardfork::London, ForkCondition::Block(0)),
+                (EthereumHardfork::Shanghai, ForkCondition::Timestamp(0)),
+                (EthereumHardfork::Cancun, ForkCondition::Timestamp(0)),
             ]
             .into_iter()
             .map(|(a, b)| (a.boxed(), b))
@@ -177,6 +180,9 @@ pub static TEVMTESTNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
                 (EthereumHardfork::Istanbul, ForkCondition::Block(0)),
                 (EthereumHardfork::MuirGlacier, ForkCondition::Block(0)),
                 (EthereumHardfork::Berlin, ForkCondition::Block(0)),
+                (EthereumHardfork::London, ForkCondition::Block(0)),
+                (EthereumHardfork::Shanghai, ForkCondition::Timestamp(0)),
+                (EthereumHardfork::Cancun, ForkCondition::Timestamp(0)),
             ]
             .into_iter()
             .map(|(a, b)| (a.boxed(), b))
@@ -208,6 +214,9 @@ pub static TEVMMAINNET_BASE: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
                 (EthereumHardfork::Istanbul, ForkCondition::Block(180698823)),
                 (EthereumHardfork::MuirGlacier, ForkCondition::Block(180698823)),
                 (EthereumHardfork::Berlin, ForkCondition::Block(180698823)),
+                (EthereumHardfork::London, ForkCondition::Block(180698823)),
+                (EthereumHardfork::Shanghai, ForkCondition::Timestamp(0)),
+                (EthereumHardfork::Cancun, ForkCondition::Timestamp(0)),
             ]
             .into_iter()
             .map(|(a, b)| (a.boxed(), b))
@@ -240,6 +249,9 @@ pub static TEVMTESTNET_BASE: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
                 (EthereumHardfork::Istanbul, ForkCondition::Block(136393756)),
                 (EthereumHardfork::MuirGlacier, ForkCondition::Block(136393756)),
                 (EthereumHardfork::Berlin, ForkCondition::Block(136393756)),
+                (EthereumHardfork::London, ForkCondition::Block(136393756)),
+                (EthereumHardfork::Shanghai, ForkCondition::Timestamp(0)),
+                (EthereumHardfork::Cancun, ForkCondition::Timestamp(0)),
             ]
             .into_iter()
             .map(|(a, b)| (a.boxed(), b))


### PR DESCRIPTION
## Summary

Activates hardforks London through Cancun on all four Telos chainspecs (mainnet, testnet, mainnet-base, testnet-base).

## Problem

Telos chainspec currently stops at Berlin. The `revm_spec()` function checks hardforks highest-to-lowest, so it returns `BERLIN` for all blocks. This means:

- **Blake2f precompile (EIP-152)** is not activated — revm gates precompiles by spec level, and BERLIN does not include Istanbul precompiles in its precompile set
- London/Shanghai/Cancun features are not formally declared despite opcodes already working via the consensus client

## Testing

Ran 75+ EVM compatibility tests against both v1.0.8 and v1.11.3 on Telos testnet:
- Shanghai opcodes (PUSH0) ✅ already working
- Cancun opcodes (TSTORE/TLOAD, MCOPY, BLOBBASEFEE) ✅ already working  
- **Blake2f precompile ❌ FAILED** on both versions — this PR fixes it
- All other precompiles (ecrecover, sha256, ripemd160, identity, modexp, ecadd, ecmul, ecpairing) ✅

## Changes

Added to all 4 Telos chainspecs in `crates/chainspec/src/spec.rs`:
```rust
(EthereumHardfork::London, ForkCondition::Block(...))
(EthereumHardfork::Shanghai, ForkCondition::Timestamp(0))
(EthereumHardfork::Cancun, ForkCondition::Timestamp(0))
```

Paris (The Merge) is intentionally skipped — PoS consensus does not apply to Telos.

## Why This Matters

Blake2f is needed for Zcash-style verification and ZK proof systems, which aligns with Telos's privacy/ZK direction. Formally enabling these hardforks also ensures compatibility with contracts that check for these features.